### PR TITLE
Consolidate CI into a single job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: clippy
+          components: clippy, llvm-tools-preview
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y unixodbc-dev
@@ -29,25 +29,10 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
-      - name: Tests
-        run: cargo test
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: llvm-tools-preview
-
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y unixodbc-dev
-
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Generate coverage
+      - name: Tests with coverage
         run: cargo llvm-cov --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary
- Merges the separate `check` and `coverage` jobs into one, avoiding duplicate setup and test runs
- Follow-up to #6

## Test plan
- [ ] Verify the workflow runs successfully from the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)