### PR TITLE
Fix unused code warnings breaking CI

### DIFF
--- a/src/backend/databricks.rs
+++ b/src/backend/databricks.rs
@@ -58,6 +58,17 @@ struct StatementError {
     message: Option<String>,
 }
 
+impl StatementError {
+    fn format_message(self) -> String {
+        match (self.error_code, self.message) {
+            (Some(code), Some(msg)) => format!("[{}] {}", code, msg),
+            (Some(code), None) => format!("[{}]", code),
+            (None, Some(msg)) => msg,
+            (None, None) => "unknown error".to_string(),
+        }
+    }
+}
+
 #[derive(Deserialize)]
 struct Manifest {
     schema: Option<SchemaInfo>,
@@ -168,7 +179,7 @@ impl DatabricksBackend {
                     let msg = response
                         .status
                         .error
-                        .and_then(|e| e.message)
+                        .map(|e| e.format_message())
                         .unwrap_or_else(|| "unknown error".to_string());
                     return Err(DbtoonError::Query { message: msg });
                 }
@@ -288,7 +299,7 @@ impl Backend for DatabricksBackend {
                 let msg = response
                     .status
                     .error
-                    .and_then(|e| e.message)
+                    .map(|e| e.format_message())
                     .unwrap_or_else(|| "unknown error".to_string());
                 Err(DbtoonError::Query { message: msg })
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,16 +93,16 @@ pub struct ExecArgs {
     pub schema: Option<String>,
 
     /// Max rows to return (default: 500)
-    #[arg(short = 'l', long, default_value = "500", env = "DBTOON_ROW_LIMIT")]
-    pub limit: usize,
+    #[arg(short = 'l', long, env = "DBTOON_ROW_LIMIT")]
+    pub limit: Option<usize>,
 
     /// Disable row limit
     #[arg(long)]
     pub no_limit: bool,
 
     /// Query timeout in seconds (default: 60)
-    #[arg(short = 't', long, default_value = "60", env = "DBTOON_TIMEOUT")]
-    pub timeout: u64,
+    #[arg(short = 't', long, env = "DBTOON_TIMEOUT")]
+    pub timeout: Option<u64>,
 
     /// Write results to file instead of stdout
     #[arg(short = 'o', long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ async fn exec_read(
     config_path: Option<&std::path::PathBuf>,
 ) -> Result<(), DbtoonError> {
     let app_config = config::load_from_exec_args(args, verbose, show_secrets, config_path)?;
+    let verbose = app_config.verbose;
 
     // Resolve SQL input
     let sql = resolve_sql(args)?;
@@ -85,6 +86,7 @@ async fn exec_write(
     config_path: Option<&std::path::PathBuf>,
 ) -> Result<(), DbtoonError> {
     let app_config = config::load_from_exec_args(args, verbose, show_secrets, config_path)?;
+    let verbose = app_config.verbose;
 
     if !app_config.allow_write {
         return Err(DbtoonError::Auth {
@@ -113,6 +115,7 @@ async fn list_warehouses(
 ) -> Result<(), DbtoonError> {
     let app_config =
         config::load_from_list_warehouses_args(args, verbose, show_secrets, config_path)?;
+    let verbose = app_config.verbose;
 
     let (host, token) = match &app_config.backend {
         config::BackendConfig::Databricks { host, token, .. } => (host.clone(), token.clone()),

--- a/tests/unit/validation_test.rs
+++ b/tests/unit/validation_test.rs
@@ -1,4 +1,4 @@
-use dbtoon::validation::{validate, BackendDialect, DenialKind, ValidationResult};
+use dbtoon::validation::{validate, BackendDialect, ValidationResult};
 
 fn assert_safe(sql: &str, dialect: BackendDialect) {
     match validate(sql, dialect) {


### PR DESCRIPTION
## Summary
- Wire up Databricks `error_code` into error messages via `StatementError::format_message()`, producing formatted output like `[SYNTAX_ERROR] Syntax error in SQL statement`
- Implement TOML config defaults layering (CLI/ENV > TOML > hardcoded) for `row_limit`, `timeout`, and `verbose` — matching the pattern already used for `allow_write`
- Remove unused `DenialKind` import in validation tests

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes with zero warnings
- [x] All 43 tests pass, including 3 new tests for explicit CLI overrides and `no_limit` precedence
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)