### PR TITLE
feat(009): Simplify CLI with profile-based commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-10
 - N/A (install receipts managed by cargo-dist installer, not by dbtoon) (006-cargo-dist-release)
 - Rust (stable, 2024 edition) + `sqlparser` 0.61 (SQL parsing + AST — already integrated), `clap` 4.5, `thiserror` 2, `anyhow` 1 (008-write-query-detection)
 - N/A — pure validation logic, no persistence changes (008-write-query-detection)
+- Rust (stable, 2024 edition) + `clap` 4.5 (CLI), `toml` 0.8 (config read), `toml_edit` 0.25 (config write — NEW), `secrecy` 0.10 (masking), `serde` 1 (deserialization), `sqlparser` 0.61 (validation) (009-simplify-cli-ui)
+- TOML config file at `~/.config/dbtoon/config.toml`; no database changes (009-simplify-cli-ui)
 
 - Rust (stable, 2024 edition) + `odbc-api` 20 (SQL Server), `reqwest` 0.12 + `tokio` 1 (Databricks), `sqlparser` 0.61 (validation), `toon-format` 0.4 (output), `clap` 4.5 (CLI), `serde`/`toml` (config), `thiserror` 2 + `anyhow` 1 (errors), `secrecy` 0.10 (credential masking) (001-multi-db-query)
 
@@ -33,9 +35,9 @@ cargo test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECH
 Rust (stable, 2024 edition): Follow standard conventions
 
 ## Recent Changes
+- 009-simplify-cli-ui: Added Rust (stable, 2024 edition) + `clap` 4.5 (CLI), `toml` 0.8 (config read), `toml_edit` 0.25 (config write — NEW), `secrecy` 0.10 (masking), `serde` 1 (deserialization), `sqlparser` 0.61 (validation)
 - 008-write-query-detection: Added Rust (stable, 2024 edition) + `sqlparser` 0.61 (SQL parsing + AST — already integrated), `clap` 4.5, `thiserror` 2, `anyhow` 1
 - 006-cargo-dist-release: Added Rust (stable, 2024 edition) + Existing (`clap` 4.5, `tokio` 1, `anyhow` 1, `thiserror` 2) + New (`axoupdater` 0.9 for self-update); cargo-dist 0.30.3 (build tooling, not a runtime dep)
-- 005-truncation-metadata: Added Rust (stable 1.91.1, 2024 edition) + Existing: `toon-format` 0.4 (TOON encoding), `arrow` 57 (Arrow schema metadata + IPC), `parquet` 57 (Parquet writer), `serde_json` 1 (JSON construction), `csv` 1.4; no new dependencies
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,6 @@ dependencies = [
  "axoupdater",
  "clap",
  "csv",
- "directories",
  "dotenvy",
  "odbc-api",
  "parquet",
@@ -688,28 +687,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "toml_edit 0.25.3+spec-1.1.0",
  "toon-format",
-]
-
-[[package]]
-name = "directories"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1965,12 +1944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "orbclient"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,17 +2292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2981,6 +2943,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,10 +2978,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.7+spec-1.1.0"
+name = "toml_edit"
+version = "0.25.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
+checksum = "a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -3020,6 +3004,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "toon-format"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-directories = "6"
+toml_edit = "0.25"
 thiserror = "2"
 anyhow = "1"
 secrecy = "0.10"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,28 @@ A multi-database query CLI that outputs results in [TOON format](https://github.
 
 ## Features
 
+- **Profile-based connections** — manage database connections as named profiles
 - **Read-only queries** with AST-based validation that rejects writes before execution
-- **Write queries** via opt-in `exec-write` command (requires `DBTOON_ALLOW_WRITE=true`)
+- **Write queries** via `--allow-write` flag on the `query` command
 - **Row limiting** with configurable limits and `--no-limit` override
-- **File output** with `--output` flag
-- **Databricks warehouse discovery** via `list-warehouses`
-- **TOML config profiles** with env var and CLI flag overrides
+- **Multiple output formats** — TOON, CSV, Parquet, Arrow IPC via `--output`
+- **Databricks warehouse discovery** via `warehouse list`
+- **Config file initialization** with `dbtoon init`
+- **`$VAR` env var references** in profile fields for secure credential management
 - **Credential masking** by default (secrets redacted in diagnostics)
+
+## Quick Start
+
+```sh
+# 1. Create a config file
+dbtoon init
+
+# 2. Create a profile
+dbtoon profile create mydb --backend sqlserver --set server=localhost --set database=mydb
+
+# 3. Run a query
+dbtoon query -P mydb "SELECT TOP 10 * FROM users"
+```
 
 ## Installation
 
@@ -40,48 +55,50 @@ cargo install dbtoon
 
 ## Updating
 
-If you installed dbtoon via the shell or PowerShell installer, you can update to the latest release with:
-
 ```sh
 dbtoon update
 ```
 
 If you installed via `cargo install`, update with `cargo install dbtoon` instead.
 
-## Build from source
-
-```sh
-cargo build --release
-```
-
 ## Usage
 
 ```sh
-# SQL Server (Windows Auth)
-dbtoon exec-read -b sqlserver -s localhost -d mydb -w "SELECT TOP 10 * FROM users"
+# SQL Server query
+dbtoon query -P dev-sql "SELECT TOP 10 * FROM users"
 
-# SQL Server (SQL Auth, self-signed cert)
-dbtoon exec-read -b sqlserver -s localhost -d mydb -u sa -p secret \
-  --trust-server-certificate "SELECT 1"
+# Databricks query
+dbtoon query -P prod-databricks "SELECT * FROM catalog.schema.table"
 
-# Databricks
-dbtoon exec-read -b databricks --host adb-123.azuredatabricks.net \
-  --warehouse abc123 --token dapi... "SELECT * FROM catalog.schema.table"
+# Query with overrides
+dbtoon query -P dev-sql -d otherdb -l 100 -t 120 "SELECT 1"
 
-# List Databricks warehouses
-dbtoon list-warehouses --host adb-123.azuredatabricks.net --token dapi...
+# Read SQL from file
+dbtoon query -P dev-sql -f query.sql
 
 # Write query (requires opt-in)
-DBTOON_ALLOW_WRITE=true dbtoon exec-write -b sqlserver -s localhost -d mydb -w \
-  "INSERT INTO logs (msg) VALUES ('hello')"
+dbtoon query -P dev-sql --allow-write "INSERT INTO logs (msg) VALUES ('hello')"
 
-# Output to file
-dbtoon exec-read -b sqlserver -s localhost -d mydb -w -o results.toon "SELECT 1"
+# Output to file (format detected by extension)
+dbtoon query -P dev-sql -o results.csv "SELECT 1"
+
+# List Databricks warehouses
+dbtoon warehouse list -P prod-databricks
+
+# Profile management
+dbtoon profile create mydb --backend sqlserver
+dbtoon profile edit mydb --set server=newhost
+dbtoon profile show mydb
+dbtoon profile list
+dbtoon profile rename mydb mydb-old
+dbtoon profile delete mydb-old
 ```
 
 ## Configuration
 
-Config file location: `~/.config/dbtoon/config.toml` (Linux), `~/Library/Application Support/dbtoon/config.toml` (macOS), or `--config <path>`.
+Config file location: `~/.config/dbtoon/config.toml` (all platforms), or use `-c <path>`.
+
+Run `dbtoon init` to create a config file with defaults and example profiles.
 
 ```toml
 [defaults]
@@ -93,41 +110,51 @@ backend = "sqlserver"
 server = "localhost,1433"
 database = "mydb"
 username = "sa"
-password_env = "MY_SQL_PASSWORD"
+password = "$MY_SQL_PASSWORD"
 trust_server_certificate = true
 
 [profiles.prod-databricks]
 backend = "databricks"
-host = "adb-123.azuredatabricks.net"
-warehouse_id = "abc123def"
-token_env = "DATABRICKS_TOKEN"
-catalog = "main"
-schema = "default"
+host = "$DATABRICKS_HOST"
+token = "$DATABRICKS_TOKEN"
+warehouse_id = "$DATABRICKS_SQL_WAREHOUSE_ID"
+catalog = "$DATABRICKS_CATALOG"
+schema = "$DATABRICKS_SCHEMA"
 ```
+
+### `$VAR` References
+
+String profile fields can reference environment variables using `$VAR` syntax:
+
+- `host = "$DATABRICKS_HOST"` — resolved at use-time from the env var
+- `host = "$$pecial"` — escaped to literal `$pecial`
+- `host = "literal.host"` — used as-is
+
+If a referenced env var is not set, dbtoon errors (no silent fallthrough).
+
+### Config Resolution Hierarchy
+
+Values are resolved in priority order:
+
+1. **CLI flags** (`--limit`, `--timeout`, `-d`, `-s`, `--allow-write`, `--no-limit`)
+2. **TOML profile** (`[profiles.<name>]` fields)
+3. **TOML defaults** (`[defaults]` section)
+4. **Databricks standard env vars** (lowest-priority fallback, Databricks only)
+
+## Databricks Standard Environment Variables
+
+For Databricks profiles, these standard env vars are used as lowest-priority fallbacks when not set in the profile or defaults:
+
+| Variable | Maps to |
+|----------|---------|
+| `DATABRICKS_HOST` | `host` |
+| `DATABRICKS_TOKEN` | `token` |
+| `DATABRICKS_SQL_WAREHOUSE_ID` | `warehouse_id` |
+| `DATABRICKS_CATALOG` | `catalog` |
+| `DATABRICKS_SCHEMA` | `schema` |
+
+## Build from source
 
 ```sh
-dbtoon exec-read -P dev-sql "SELECT 1"
+cargo build --release
 ```
-
-## Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `DBTOON_BACKEND` | Backend type (`sqlserver` or `databricks`) |
-| `DBTOON_SERVER` | SQL Server hostname |
-| `DBTOON_DATABASE` | Database name |
-| `DBTOON_USERNAME` | SQL Auth username |
-| `DBTOON_PASSWORD` | SQL Auth password |
-| `DBTOON_WINDOWS_AUTH` | Use Windows Integrated Auth |
-| `DBTOON_TRUST_SERVER_CERT` | Trust SQL Server certificate |
-| `DBTOON_DATABRICKS_HOST` | Databricks workspace host |
-| `DBTOON_DATABRICKS_TOKEN` | Databricks bearer token |
-| `DBTOON_WAREHOUSE_ID` | Databricks SQL warehouse ID |
-| `DBTOON_CATALOG` | Databricks catalog |
-| `DBTOON_SCHEMA` | Databricks schema |
-| `DBTOON_ROW_LIMIT` | Default row limit |
-| `DBTOON_TIMEOUT` | Query timeout in seconds |
-| `DBTOON_ALLOW_WRITE` | Enable write queries (`true`) |
-| `DBTOON_CONFIG` | Config file path |
-| `DBTOON_VERBOSE` | Enable verbose diagnostics |
-| `DBTOON_SHOW_SECRETS` | Disable credential masking |

--- a/specs/009-simplify-cli-ui/checklists/requirements.md
+++ b/specs/009-simplify-cli-ui/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Simplify CLI Interface
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec is comprehensive with 8 user stories, 25 functional requirements, 8 edge cases, and 7 measurable success criteria.
+- Clarification session resolved field removal semantics and simplified env-var indirection from dual `_env` fields to inline `$VAR` syntax, reducing overall complexity.
+- The `$VAR` change eliminated the old FR-018 (mutual exclusivity) and renumbered FR-018 through FR-026 down to FR-018 through FR-025.

--- a/specs/009-simplify-cli-ui/contracts/cli-interface.md
+++ b/specs/009-simplify-cli-ui/contracts/cli-interface.md
@@ -1,0 +1,150 @@
+# CLI Interface Contract: Simplify CLI Interface
+
+**Feature Branch**: `009-simplify-cli-ui` | **Date**: 2026-02-19
+
+This document defines the complete CLI interface contract after the restructuring. It serves as the authoritative reference for clap struct definitions.
+
+## Global Flags
+
+| Flag | Short | Type | Default | Env | Description |
+|------|-------|------|---------|-----|-------------|
+| `--config` | `-c` | `PathBuf` | `~/.config/dbtoon/config.toml` | — | Config file path |
+| `--verbose` | `-v` | `bool` | `false` | — | Emit diagnostics to stderr |
+| `--show-secrets` | — | `bool` | `false` | — | Disable credential masking |
+
+**Note**: No `DBTOON_*` env vars. Global flags are CLI-only.
+
+## Commands
+
+### `dbtoon init`
+
+Creates a config file with defaults and example profiles.
+
+| Arg/Flag | Type | Description |
+|----------|------|-------------|
+| *(none)* | — | Uses global `--config` or default path |
+
+**Exit codes**: 0 = created, 1 = already exists or write error
+
+---
+
+### `dbtoon query`
+
+Execute a SQL query against a profile.
+
+| Arg/Flag | Short | Type | Required | Description |
+|----------|-------|------|----------|-------------|
+| `<SQL>` | — | positional | one of SQL/`-f` | SQL query text |
+| `--file` | `-f` | `PathBuf` | one of SQL/`-f` | Read SQL from file |
+| `--profile` | `-P` | `String` | **yes** | Profile name |
+| `--database` | `-d` | `String` | no | Override catalog/database (alias: `--catalog`) |
+| `--catalog` | — | `String` | no | Override catalog/database (alias: `--database`) |
+| `--schema` | `-s` | `String` | no | Override schema |
+| `--limit` | `-l` | `usize` | no | Override row limit |
+| `--no-limit` | — | `bool` | no | Disable row limit |
+| `--timeout` | `-t` | `u64` | no | Override timeout (seconds) |
+| `--output` | `-o` | `PathBuf` | no | Write to file (format by extension) |
+| `--allow-write` | — | `bool` | no | Bypass read-only safety |
+
+**Conflicts**: `<SQL>` vs `--file`, `--database` vs `--catalog`
+
+---
+
+### `dbtoon profile create <NAME>`
+
+Create a new profile.
+
+| Arg/Flag | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<NAME>` | positional | **yes** | Profile name |
+| `--backend` | `String` | **yes** | `databricks` or `sqlserver` |
+| `--set` | `Vec<String>` | no | `key=value` pairs (repeatable) |
+
+---
+
+### `dbtoon profile edit <NAME>`
+
+Edit an existing profile.
+
+| Arg/Flag | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<NAME>` | positional | **yes** | Profile name |
+| `--set` | `Vec<String>` | no | `key=value` pairs; `key=` removes field (repeatable) |
+| `--unset` | `Vec<String>` | no | Field names to remove (repeatable) |
+
+---
+
+### `dbtoon profile show <NAME>`
+
+Display profile with resolved values and masking.
+
+| Arg/Flag | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<NAME>` | positional | **yes** | Profile name |
+
+---
+
+### `dbtoon profile list`
+
+List all profile names. No arguments.
+
+---
+
+### `dbtoon profile test <NAME>`
+
+Test connectivity for a profile.
+
+| Arg/Flag | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<NAME>` | positional | **yes** | Profile name |
+
+---
+
+### `dbtoon profile delete <NAME>`
+
+Delete a profile from config.
+
+| Arg/Flag | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<NAME>` | positional | **yes** | Profile name |
+
+---
+
+### `dbtoon profile rename <OLD> <NEW>`
+
+Rename a profile.
+
+| Arg/Flag | Type | Required | Description |
+|----------|------|----------|-------------|
+| `<OLD>` | positional | **yes** | Current name |
+| `<NEW>` | positional | **yes** | New name |
+
+---
+
+### `dbtoon warehouse list`
+
+List Databricks SQL warehouses.
+
+| Arg/Flag | Short | Type | Required | Description |
+|----------|-------|------|----------|-------------|
+| `--profile` | `-P` | `String` | **yes** | Databricks profile name |
+
+---
+
+### `dbtoon update`
+
+Self-update to latest release. No arguments.
+
+## Removed (Compared to Current CLI)
+
+### Removed Commands
+- `exec-read` → use `query`
+- `exec-write` → use `query --allow-write`
+- `list-warehouses` → use `warehouse list`
+
+### Removed Flags (from query/warehouse)
+- `--backend`, `--server`, `--host`, `--token`, `--warehouse`
+- `--username`, `--password`, `--windows-auth`, `--trust-server-certificate`
+
+### Removed Env Vars
+- All `DBTOON_*` env vars (`DBTOON_CONFIG`, `DBTOON_VERBOSE`, `DBTOON_SHOW_SECRETS`, `DBTOON_BACKEND`, `DBTOON_SERVER`, `DBTOON_DATABASE`, `DBTOON_USERNAME`, `DBTOON_PASSWORD`, `DBTOON_WINDOWS_AUTH`, `DBTOON_TRUST_SERVER_CERT`, `DBTOON_DATABRICKS_HOST`, `DBTOON_DATABRICKS_TOKEN`, `DBTOON_WAREHOUSE_ID`, `DBTOON_CATALOG`, `DBTOON_SCHEMA`, `DBTOON_ROW_LIMIT`, `DBTOON_TIMEOUT`, `DBTOON_PROFILE`, `DBTOON_ALLOW_WRITE`)

--- a/specs/009-simplify-cli-ui/contracts/config-file.md
+++ b/specs/009-simplify-cli-ui/contracts/config-file.md
@@ -1,0 +1,63 @@
+# Config File Contract: Simplify CLI Interface
+
+**Feature Branch**: `009-simplify-cli-ui` | **Date**: 2026-02-19
+
+## File Format
+
+TOML 1.0. Located at `~/.config/dbtoon/config.toml`.
+
+## Schema
+
+```toml
+# Global defaults — applied when not overridden by profile or CLI flags
+[defaults]
+row_limit = 500          # usize, optional, default 500
+timeout = 60             # u64 seconds, optional, default 60
+verbose = false          # bool, optional, default false
+allow_write = false      # bool, optional, default false
+
+# Named connection profiles
+[profiles.<name>]
+backend = "<type>"       # Required: "databricks" | "sqlserver"
+# ... backend-specific fields (see below)
+```
+
+## Databricks Profile Fields
+
+```toml
+[profiles.my_databricks]
+backend = "databricks"
+host = "$DATABRICKS_HOST"                      # string, required
+token = "$DATABRICKS_TOKEN"                    # string (secret), required
+warehouse_id = "$DATABRICKS_SQL_WAREHOUSE_ID"  # string, required
+catalog = "$DATABRICKS_CATALOG"                # string, optional
+schema = "$DATABRICKS_SCHEMA"                  # string, optional
+```
+
+## SQL Server Profile Fields
+
+```toml
+[profiles.my_sqlserver]
+backend = "sqlserver"
+server = "localhost"                  # string, required
+database = "mydb"                    # string, optional
+username = "sa"                      # string, required if !windows_auth
+password = "$SA_PASSWORD"            # string (secret), required if !windows_auth
+windows_auth = false                 # bool, optional, default false
+trust_server_certificate = false     # bool, optional, default false
+```
+
+## $VAR Resolution Rules
+
+1. A string value starting with `$` (not `$$`) is an env var reference
+2. The env var must be set and non-empty, or it is an error
+3. `$$` at the start escapes to a literal `$` (e.g., `$$pecial` → `$pecial`)
+4. Resolution occurs at **use-time** (when the profile is used for a query), not at parse-time
+5. Only applies to **string-typed** fields. `windows_auth` and `trust_server_certificate` (bool) are always literal.
+
+## Invariants
+
+- Profile names are case-sensitive, valid TOML keys
+- No duplicate profile names
+- `backend` field is mandatory in every profile
+- Comments and formatting are preserved across `profile` subcommand edits (via `toml_edit`)

--- a/specs/009-simplify-cli-ui/data-model.md
+++ b/specs/009-simplify-cli-ui/data-model.md
@@ -1,0 +1,131 @@
+# Data Model: Simplify CLI Interface
+
+**Feature Branch**: `009-simplify-cli-ui` | **Date**: 2026-02-19
+
+## Entities
+
+### Config File
+
+**Location**: `~/.config/dbtoon/config.toml` (all platforms)
+**Format**: TOML
+**Lifecycle**: Created by `dbtoon init`, modified by `profile` subcommands, read by `query`/`warehouse`
+
+```toml
+[defaults]
+row_limit = 500        # usize, optional (default: 500)
+timeout = 60           # u64 seconds, optional (default: 60)
+verbose = false        # bool, optional (default: false)
+allow_write = false    # bool, optional (default: false)
+
+[profiles.<name>]
+backend = "databricks"                # Required: "databricks" | "sqlserver"
+# ... backend-specific fields below
+```
+
+### Profile (Databricks)
+
+| Field | Type | Required | `$VAR` | Default `$VAR` |
+|-------|------|----------|--------|-----------------|
+| `backend` | string | yes | no | — |
+| `host` | string | yes | yes | `$DATABRICKS_HOST` |
+| `token` | string (secret) | yes | yes | `$DATABRICKS_TOKEN` |
+| `warehouse_id` | string | yes | yes | `$DATABRICKS_SQL_WAREHOUSE_ID` |
+| `catalog` | string | no | yes | `$DATABRICKS_CATALOG` |
+| `schema` | string | no | yes | `$DATABRICKS_SCHEMA` |
+
+### Profile (SQL Server)
+
+| Field | Type | Required | `$VAR` | Default `$VAR` |
+|-------|------|----------|--------|-----------------|
+| `backend` | string | yes | no | — |
+| `server` | string | yes | yes | — |
+| `database` | string | no | yes | — |
+| `username` | string | cond.* | yes | — |
+| `password` | string (secret) | cond.* | yes | — |
+| `windows_auth` | bool | no | no | `false` |
+| `trust_server_certificate` | bool | no | no | `false` |
+
+*\*Required when `windows_auth` is not `true`.*
+
+### Defaults
+
+Global fallbacks in `[defaults]`. Applied when not overridden by profile or CLI flags.
+
+| Field | Type | Default |
+|-------|------|---------|
+| `row_limit` | usize | 500 |
+| `timeout` | u64 | 60 |
+| `verbose` | bool | false |
+| `allow_write` | bool | false |
+
+## Configuration Resolution Hierarchy
+
+Priority (highest first):
+1. **CLI flags** (`--limit`, `--timeout`, `-d`, `-s`, `--allow-write`, `--no-limit`)
+2. **TOML profile** (`[profiles.<name>]` fields)
+3. **TOML defaults** (`[defaults]` section)
+4. **Databricks standard env vars** (lowest-priority fallback, Databricks backend only)
+
+A `$VAR` reference to an unset variable is an **error** — no fallthrough to the next level.
+
+## State Transitions
+
+### Config File Lifecycle
+
+```
+[not exists] --init--> [exists with defaults + example profiles]
+[exists]     --profile create--> [profile added]
+[exists]     --profile edit--> [profile field modified/added/removed]
+[exists]     --profile delete--> [profile removed]
+[exists]     --profile rename--> [profile renamed]
+```
+
+### $VAR Resolution
+
+```
+"$VARNAME" --resolve--> env var value (or error if unset)
+"$$literal" --resolve--> "$literal"
+"plain"    --resolve--> "plain" (unchanged)
+```
+
+## Validation Rules
+
+- Profile names: valid TOML key names, case-sensitive
+- Profile names: must not already exist (for `create`), must exist (for `edit`/`delete`/`rename`/`show`/`test`)
+- Backend: must be `"databricks"` or `"sqlserver"`
+- `$VAR` resolution: only on string-typed fields; bool/numeric fields are always literals
+- `--database`/`--catalog`: true aliases, mutually exclusive (clap conflict group)
+- SQL input: exactly one of positional SQL or `-f` (clap `conflicts_with`)
+
+## Struct Changes (Rust)
+
+### New: `TomlProfile` updates
+
+Remove `password_env` and `token_env` fields (replaced by `$VAR` syntax within `password`/`token` fields).
+
+### New: CLI struct hierarchy
+
+```
+Cli
+├── --config, --verbose, --show-secrets (global)
+├── init (InitArgs) — new
+├── query (QueryArgs) — replaces ExecRead/ExecWrite
+│   ├── -P/--profile (required)
+│   ├── SQL (positional) | -f/--file
+│   ├── -d/--database, --catalog (aliases, conflict group)
+│   ├── -s/--schema
+│   ├── -l/--limit, --no-limit, -t/--timeout
+│   ├── -o/--output
+│   └── --allow-write
+├── profile (ProfileCommand) — new
+│   ├── create <name> --backend [--set key=value...]
+│   ├── edit <name> [--set key=value...] [--unset key...]
+│   ├── show <name>
+│   ├── list
+│   ├── test <name>
+│   ├── delete <name>
+│   └── rename <old> <new>
+├── warehouse
+│   └── list -P <profile>
+└── update
+```

--- a/specs/009-simplify-cli-ui/plan.md
+++ b/specs/009-simplify-cli-ui/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Simplify CLI Interface
+
+**Branch**: `009-simplify-cli-ui` | **Date**: 2026-02-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/009-simplify-cli-ui/spec.md`
+
+## Summary
+
+Restructure the dbtoon CLI to separate connection management from query execution. Replace `exec-read`/`exec-write` with a unified `query` command requiring `-P <profile>`, add `profile` management subcommands (create/edit/show/list/test/delete/rename), add `dbtoon init` for config bootstrapping, and remove all `DBTOON_*` environment variables in favor of `$VAR` references within TOML profiles and Databricks standard env vars as lowest-priority fallbacks.
+
+**Key technical decisions** (from [research.md](research.md)):
+- `toml_edit` 0.25 for format-preserving config writes
+- Simple `resolve_env_var()` function for `$VAR`/`$$` resolution (~15 lines)
+- `HOME`-based config path instead of `directories` crate (force `~/.config/dbtoon/` on macOS)
+
+## Technical Context
+
+**Language/Version**: Rust (stable, 2024 edition)
+**Primary Dependencies**: `clap` 4.5 (CLI), `toml` 0.8 (config read), `toml_edit` 0.25 (config write — NEW), `secrecy` 0.10 (masking), `serde` 1 (deserialization), `sqlparser` 0.61 (validation)
+**Storage**: TOML config file at `~/.config/dbtoon/config.toml`; no database changes
+**Testing**: `cargo test` (unit tests in `tests/unit/`)
+**Target Platform**: macOS, Linux (cross-platform via `HOME` env var)
+**Project Type**: Single Rust binary (CLI tool)
+**Performance Goals**: N/A — config operations are sub-second
+**Constraints**: Must preserve existing query execution behavior exactly; only the config/CLI surface changes
+**Scale/Scope**: ~18 source files, ~5 new/modified test files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Research Gate
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Simplicity First** | PASS | CLI restructure explicitly simplifies the user-facing interface (3 commands → clear subcommand hierarchy) |
+| **II. Engineering Fundamentals** | PASS | DRY: unified `query` replaces duplicated `exec-read`/`exec-write`. SoC: profile management separated from query execution. Least Surprise: `-P` profile pattern is conventional. |
+| **III. Over-Engineering Guards** | PASS | No premature abstractions. `$VAR` resolution is a 15-line function. Profile CRUD uses `toml_edit` directly. |
+| **IV. TDD** | GATE | Tests must be written before implementation for each unit. |
+| **V. Incremental Delivery** | GATE | Each task must produce a compilable, test-passing commit. |
+
+### Post-Design Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Simplicity** | PASS | Data model has 2 profile types with small, well-defined field sets. No abstraction layers. |
+| **II. Fundamentals** | PASS | Single `resolve_env_var()` for all `$VAR` fields (DRY). Config resolution hierarchy is explicit with clear precedence (Explicit > Implicit). |
+| **III. Guards** | PASS | No new abstractions beyond what the spec requires. `toml_edit` is used directly, not wrapped. |
+| **IV. TDD** | PASS | Testing strategy defined: unit tests for resolution/validation, integration tests for CLI parsing and config round-trips. |
+| **V. Incremental** | PASS | Implementation order in quickstart.md defines 11 independently deliverable steps. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-simplify-cli-ui/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── cli-interface.md # Complete CLI contract
+│   └── config-file.md   # Config file schema contract
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── cli.rs               # MODIFY: Replace Command enum, new QueryArgs/ProfileCommand/etc.
+├── config.rs            # MODIFY: $VAR resolution, HOME-based path, remove directories dep
+├── init.rs              # NEW: dbtoon init command logic
+├── profile.rs           # NEW: Profile CRUD via toml_edit
+├── main.rs              # MODIFY: New command dispatch
+├── error.rs             # UNCHANGED
+├── lib.rs               # MODIFY: Add pub mod init, profile
+├── backend/             # UNCHANGED
+├── format*.rs           # UNCHANGED
+├── masking.rs           # UNCHANGED
+├── output.rs            # UNCHANGED
+├── update.rs            # UNCHANGED
+├── validation.rs        # UNCHANGED
+└── verbose.rs           # UNCHANGED
+
+tests/
+└── unit/
+    ├── config_test.rs         # MODIFY: $VAR resolution tests, config path tests
+    ├── init_test.rs           # NEW: init command tests
+    ├── profile_test.rs        # NEW: profile CRUD tests
+    ├── cli_test.rs            # NEW: CLI argument parsing tests
+    └── ... (existing unchanged)
+```
+
+**Structure Decision**: Single project structure (existing). Two new source modules (`init.rs`, `profile.rs`) and corresponding test files. No structural reorganization — the flat `src/` layout matches the existing codebase.
+
+## Complexity Tracking
+
+No constitution violations to justify. The design uses:
+- One new dependency (`toml_edit`) — necessary for comment-preserving TOML edits
+- Two new source modules — each addresses a single concern (init, profile management)
+- One removed dependency (`directories`) — replaced by simpler `HOME`-based path

--- a/specs/009-simplify-cli-ui/quickstart.md
+++ b/specs/009-simplify-cli-ui/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Simplify CLI Interface
+
+**Feature Branch**: `009-simplify-cli-ui` | **Date**: 2026-02-19
+
+## Developer Setup
+
+```bash
+git checkout 009-simplify-cli-ui
+cargo build
+cargo test
+cargo clippy
+```
+
+## New Dependency
+
+Add `toml_edit = "0.25"` to `[dependencies]` in `Cargo.toml`. Remove `directories = "6"`.
+
+## Key Files to Modify
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Add `toml_edit`, remove `directories` |
+| `src/cli.rs` | Replace `Command` enum: remove `ExecRead`/`ExecWrite`/`ListWarehouses`, add `Init`/`Query`/`Profile`/`Warehouse` |
+| `src/config.rs` | Add `$VAR` resolution, replace `ProjectDirs` with `HOME`-based path, config-missing error |
+| `src/init.rs` | `dbtoon init` command logic (template generation, env var detection, directory creation) |
+| `src/profile.rs` | Profile CRUD via `toml_edit` (create, edit, show, list, test, delete, rename) |
+| `src/main.rs` | Update command dispatch to new enum, add `init`/`profile`/`warehouse` handlers |
+| `src/error.rs` | No changes needed (existing variants cover all new errors) |
+| `tests/unit/config_test.rs` | Add tests for `$VAR` resolution, config path, profile CRUD |
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `src/profile.rs` | Profile management logic (create, edit, show, list, test, delete, rename) |
+| `src/init.rs` | `dbtoon init` command logic |
+| `tests/unit/profile_test.rs` | Profile management tests |
+| `tests/unit/init_test.rs` | Init command tests |
+
+## Implementation Order
+
+1. **Config path** — Replace `directories` with `HOME`-based path
+2. **$VAR resolution** — Add `resolve_env_var()` and friends
+3. **CLI restructure** — New clap structs (compiles but handlers stub `todo!()`)
+4. **Init command** — Template generation + env var detection
+5. **Profile CRUD** — create/edit/show/list/delete/rename via `toml_edit`
+6. **Query command** — Wire up new `QueryArgs` to existing execution logic
+7. **Warehouse command** — Wire up `warehouse list` with `-P` required
+8. **Profile test** — Connectivity check
+9. **Remove legacy** — Delete old structs, remove `DBTOON_*` env vars
+10. **Config resolution hierarchy** — Integrate CLI > profile > defaults > env precedence
+11. **README + help text** — Update documentation
+
+## Testing Strategy
+
+- **Unit tests**: `$VAR` resolution, profile field validation, config path, template generation
+- **Integration tests**: CLI argument parsing (clap), config file round-trips, init in temp dirs
+- **No live DB tests needed**: Existing backend tests are unchanged; new tests focus on config/CLI layer

--- a/specs/009-simplify-cli-ui/research.md
+++ b/specs/009-simplify-cli-ui/research.md
@@ -1,0 +1,131 @@
+# Research: Simplify CLI Interface
+
+**Feature Branch**: `009-simplify-cli-ui` | **Date**: 2026-02-19
+
+## R1: TOML File Editing (Preserving Comments)
+
+**Decision**: Add `toml_edit = "0.25"` for config write operations alongside existing `toml = "0.8"` for reads.
+
+**Rationale**: `toml_edit` is the only Rust crate that preserves comments, formatting, and ordering during edits. Both crates are from the same `toml-rs` monorepo and are designed to coexist. The existing `toml` crate loses all comments on serialization.
+
+**Alternatives Considered**:
+- **toml only**: Cannot preserve comments — config file would lose user formatting on every `profile` write.
+- **toml_edit only**: Would require rewriting all existing deserialization code that uses serde. Unnecessary change.
+- **Template-based generation**: Would be fragile and can't handle arbitrary user edits to the config file.
+
+**API Pattern**:
+```rust
+use toml_edit::{DocumentMut, value, Item, Table};
+
+let content = fs::read_to_string(path)?;
+let mut doc = content.parse::<DocumentMut>()?;
+
+// Add a profile
+let mut profile = Table::new();
+profile["backend"] = value("databricks");
+profile["host"] = value("$DATABRICKS_HOST");
+doc["profiles"]["mydb"] = Item::Table(profile);
+
+// Remove a profile
+doc["profiles"].as_table_mut().unwrap().remove("mydb");
+
+// Write back (comments preserved)
+fs::write(path, doc.to_string())?;
+```
+
+## R2: Environment Variable Reference Resolution (`$VAR` Syntax)
+
+**Decision**: Simple `resolve_env_var(s: &str) -> Result<String, DbtoonError>` function. No wrapper types, no external crates.
+
+**Rationale**: The `$VAR` / `$$` rules are simple enough (~15 lines) that a dedicated crate would be overkill. A plain function matches the existing codebase patterns (`env_non_empty()`, `resolve_secret()`). Resolution at use-time means TOML structs stay as simple `Option<String>` fields.
+
+**Alternatives Considered**:
+- **`shellexpand` crate**: Does full shell expansion (`~`, `$HOME`, etc.) — far more than needed, risk of unexpected behavior.
+- **Wrapper type (e.g., `EnvString`)**: Requires implementing `Deserialize`, `Debug`, `Clone`, etc. Unnecessary complexity for a value that's just a string until resolution.
+- **Parse-time resolution**: Would prevent showing the original `$VAR` reference in `profile show`. Use-time resolution is spec-required.
+
+**Implementation**:
+```rust
+fn resolve_env_var(value: &str) -> Result<String, DbtoonError> {
+    if let Some(rest) = value.strip_prefix("$$") {
+        Ok(format!("${}", rest))  // Escape
+    } else if let Some(var_name) = value.strip_prefix('$') {
+        std::env::var(var_name).map_err(|_| DbtoonError::Config {
+            message: format!("environment variable '{}' is not set", var_name),
+        })
+    } else {
+        Ok(value.to_string())  // Literal
+    }
+}
+```
+
+**Companion functions**: `resolve_profile_string()` → `Option<String>`, `resolve_profile_secret()` → `Option<SecretString>`.
+
+## R3: Config Path (`~/.config/dbtoon/` on All Platforms)
+
+**Decision**: Replace `directories::ProjectDirs` with `std::env::var("HOME")` + hardcoded `.config/dbtoon/config.toml`.
+
+**Rationale**: The spec requires `~/.config/dbtoon/` on ALL platforms including macOS. The `directories` crate returns `~/Library/Application Support/dbtoon/` on macOS and cannot be overridden. The requirement is a single fixed path — no XDG_CONFIG_HOME override needed.
+
+**Alternatives Considered**:
+- **`directories` crate**: Cannot produce XDG paths on macOS. Would need a macOS-specific override, defeating the purpose.
+- **`xdg` crate**: Respects `XDG_CONFIG_HOME` and defaults to `~/.config`, but adds an unnecessary dependency for what is a single `PathBuf::join`.
+- **`dirs` crate**: Same limitation as `directories` on macOS.
+
+**Implementation**:
+```rust
+fn default_config_path() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".config/dbtoon/config.toml"))
+}
+```
+
+**Side effect**: Remove `directories` from `Cargo.toml` dependencies.
+
+## R4: Profile Field Validation
+
+**Decision**: Derive valid fields from existing Rust connection structs. No new enum or registry needed.
+
+**Rationale**: The `DatabricksBackend` and `SqlServerBackend` structs already define the canonical fields. Validation can be a `match` on backend type returning `&[&str]` of valid field names.
+
+**Canonical fields per backend**:
+
+| Backend | Fields |
+|---------|--------|
+| **databricks** | `host`, `token`, `warehouse_id`, `catalog`, `schema` |
+| **sqlserver** | `server`, `database`, `username`, `password`, `windows_auth`, `trust_server_certificate` |
+
+**Common fields** (all backends): `backend` (required, set at creation)
+
+## R5: `dbtoon init` Template Generation
+
+**Decision**: Embed the default config template as a `const &str` in the binary. Use string interpolation for conditional uncommenting of Databricks profile when env vars are detected.
+
+**Rationale**: The template is small (~30 lines), rarely changes, and needs conditional logic (detect env vars → uncomment profile). Embedding avoids filesystem dependencies.
+
+**Default template structure**:
+```toml
+[defaults]
+row_limit = 500
+timeout = 60
+
+# Example profiles — uncomment and configure:
+#
+# [profiles.sqlserver_example]
+# backend = "sqlserver"
+# server = "localhost"
+# database = "mydb"
+# username = "sa"
+# password = "$SA_PASSWORD"
+#
+# [profiles.databricks_example]
+# backend = "databricks"
+# host = "$DATABRICKS_HOST"
+# token = "$DATABRICKS_TOKEN"
+# warehouse_id = "$DATABRICKS_SQL_WAREHOUSE_ID"
+# catalog = "$DATABRICKS_CATALOG"
+# schema = "$DATABRICKS_SCHEMA"
+```
+
+When Databricks env vars are detected during `init`, the Databricks profile section is uncommented.

--- a/specs/009-simplify-cli-ui/spec.md
+++ b/specs/009-simplify-cli-ui/spec.md
@@ -1,0 +1,228 @@
+# Feature Specification: Simplify CLI Interface
+
+**Feature Branch**: `009-simplify-cli-ui`
+**Created**: 2026-02-19
+**Status**: Draft
+**Input**: User description: "Restructure the dbtoon CLI to separate connection management from query execution, replace exec-read/exec-write with a unified query command, and add profile management commands." (Issue #14)
+
+## Clarifications
+
+### Session 2026-02-19
+
+- Q: How does `profile edit` handle field removal? → A: Two mechanisms: (1) `--set key=` (empty value) removes the field, (2) `--unset key` flag exists for explicit removal. Both `profile create --set` and `profile edit --set` support the same syntax.
+- Q: Should env-var indirection use separate `_env` fields (e.g., `host`/`host_env`) or inline `$VAR` syntax? → A: Use `$VAR` syntax within the same field (e.g., `host = "$DATABRICKS_HOST"`). A value starting with `$` is resolved as an env var reference; `$$` escapes a literal dollar sign. This eliminates dual-field complexity entirely. On the CLI, `--set host='$DATABRICKS_HOST'` requires shell quoting to prevent shell expansion; unquoted `--set host=$DATABRICKS_HOST` passes the resolved literal value, which is also valid.
+- Q: How are valid profile fields per backend defined? → A: Derived from existing Rust connection structs. The implementation plan will document the canonical field list per backend. No new spec-level enumeration needed.
+- Q: Should removed commands/flags produce migration hints or be simply unrecognized? → A: Clean break — removed commands are simply unrecognized (clap default). No migration messages needed; this is pre-release software with a single user.
+- Q: Are `--database` and `--catalog` true aliases or backend-dependent flags? → A: True aliases for a single internal field (canonically `catalog`). Both set the same value regardless of backend. SQL Server "database" and Databricks "catalog" are the same concept in this tool's abstraction.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - First-Time Setup with Config Initialization (Priority: P1)
+
+A new user installs dbtoon and runs `dbtoon init` to create their configuration file. The system generates a config file at `~/.config/dbtoon/config.toml` with sensible defaults and example profiles. If Databricks standard environment variables are detected, the Databricks profile is auto-populated with `$VAR` references and uncommented. The user receives clear guidance on what to do next.
+
+**Why this priority**: Without a config file, no other commands work. This is the entry point for all users.
+
+**Independent Test**: Can be fully tested by running `dbtoon init` in a clean environment and verifying the generated config file contents and stdout output.
+
+**Acceptance Scenarios**:
+
+1. **Given** no config file exists, **When** the user runs `dbtoon init`, **Then** a config file is created at `~/.config/dbtoon/config.toml` with a `[defaults]` section and commented-out example profiles, and stdout shows the file path and next-step instructions.
+2. **Given** Databricks standard env vars (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`) are set, **When** the user runs `dbtoon init`, **Then** the Databricks profile is uncommented with `$VAR` references (e.g., `host = "$DATABRICKS_HOST"`), and stdout lists which required fields are still missing.
+3. **Given** no Databricks env vars are set, **When** the user runs `dbtoon init`, **Then** both example profiles remain commented out, and stdout explains how to create profiles.
+4. **Given** a config file already exists, **When** the user runs `dbtoon init`, **Then** the system warns that a config file already exists and does not overwrite it.
+
+---
+
+### User Story 2 - Execute a Query Using a Profile (Priority: P1)
+
+A user runs a SQL query against a configured database profile using the unified `query` command. The user specifies which profile to use with `-P`, and can optionally override row limits, timeouts, database/catalog, and schema at the command level.
+
+**Why this priority**: Query execution is the core value of dbtoon. This replaces the previous `exec-read` and `exec-write` commands.
+
+**Independent Test**: Can be tested by creating a profile and running `dbtoon query -P <profile> "SELECT 1"` to verify query execution, output, and flag handling.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid profile "dev" exists, **When** the user runs `dbtoon query -P dev "SELECT 1"`, **Then** the query executes using the profile's connection settings and results are displayed.
+2. **Given** a valid profile exists, **When** the user runs `dbtoon query -P dev -f query.sql`, **Then** the SQL is read from the file and executed.
+3. **Given** both positional SQL and `-f` are provided, **When** the user runs the command, **Then** the system reports an error about the conflict.
+4. **Given** a profile with `row_limit = 500`, **When** the user runs `dbtoon query -P dev --no-limit "SELECT *"`, **Then** all rows are returned without limit.
+5. **Given** a profile exists, **When** the user runs `dbtoon query -P dev -d otherdb "SELECT 1"`, **Then** the query executes against the overridden database/catalog.
+6. **Given** no `-P` flag is provided, **When** the user runs `dbtoon query "SELECT 1"`, **Then** the system reports an error that `-P` is required.
+7. **Given** a write query (e.g., `INSERT`), **When** the user runs without `--allow-write`, **Then** the system blocks the query with a safety message.
+8. **Given** a write query, **When** the user runs with `--allow-write`, **Then** the query executes normally.
+
+---
+
+### User Story 3 - Profile Management (Priority: P2)
+
+A user manages connection profiles through subcommands: creating, editing, viewing, listing, testing, deleting, and renaming profiles. This replaces passing connection details as inline flags.
+
+**Why this priority**: Profile management is how users configure connections. Without it, the `query` command has no profiles to use, but profiles can also be created by editing the config file directly.
+
+**Independent Test**: Can be tested by running `dbtoon profile create`, `profile show`, `profile list`, etc., and verifying the config file is updated correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a config file exists, **When** the user runs `dbtoon profile create mydb --backend sqlserver`, **Then** a new `[profiles.mydb]` section is added to the config with `$VAR` defaults for SQL Server.
+2. **Given** a config file exists, **When** the user runs `dbtoon profile create mydb --backend databricks --set host=ws.databricks.net`, **Then** the profile is created with the literal `host` value overriding the default `$VAR` reference.
+3. **Given** a profile "mydb" exists, **When** the user runs `dbtoon profile edit mydb --set database=newdb`, **Then** the profile's `database` field is updated.
+4. **Given** a profile "mydb" exists with `token = "$MY_TOKEN"` and the env var is set, **When** the user runs `dbtoon profile show mydb`, **Then** the display shows the env var name, the masked resolved value, and no warnings.
+5. **Given** a profile "mydb" exists with `token = "$MY_TOKEN"` and the env var is NOT set, **When** the user runs `dbtoon profile show mydb`, **Then** a warning indicates the env var is unset.
+6. **Given** multiple profiles exist, **When** the user runs `dbtoon profile list`, **Then** all profile names are listed.
+7. **Given** a profile "mydb" exists, **When** the user runs `dbtoon profile test mydb`, **Then** the system attempts a connection and reports success or the specific failure.
+8. **Given** a profile "mydb" exists, **When** the user runs `dbtoon profile delete mydb`, **Then** the profile is removed from the config.
+9. **Given** a profile "old" exists, **When** the user runs `dbtoon profile rename old new`, **Then** the profile is renamed to "new" in the config.
+10. **Given** a profile "mydb" has `host = "wrong.host"`, **When** the user runs `dbtoon profile edit mydb --set 'host=$DATABRICKS_HOST'`, **Then** the `host` field is updated to the `$VAR` reference.
+11. **Given** a profile "mydb" has `database = "olddb"`, **When** the user runs `dbtoon profile edit mydb --unset database`, **Then** the `database` field is removed from the profile.
+12. **Given** a profile "mydb" has `server = "old"`, **When** the user runs `dbtoon profile edit mydb --set server=`, **Then** the `server` field is removed from the profile.
+
+---
+
+### User Story 4 - Warehouse Listing via Profile (Priority: P3)
+
+A user lists available Databricks warehouses using a profile for connection details instead of inline flags.
+
+**Why this priority**: Existing functionality that needs to be migrated to use profiles. Lower priority because the core behavior is unchanged.
+
+**Independent Test**: Can be tested by running `dbtoon warehouse list -P <databricks-profile>` and verifying warehouse list is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Databricks profile "dbx" exists, **When** the user runs `dbtoon warehouse list -P dbx`, **Then** the available warehouses are listed.
+2. **Given** `--host` or `--token` flags are passed to `warehouse list`, **When** the command runs, **Then** clap rejects them as unrecognized flags (clean break, no migration message).
+
+---
+
+### User Story 5 - Config File Requirement Enforcement (Priority: P1)
+
+When no config file exists, all commands that require one (query, profile *, warehouse list) display a clear error directing the user to run `dbtoon init`.
+
+**Why this priority**: Prevents confusing errors when the user hasn't set up yet.
+
+**Independent Test**: Can be tested by deleting or renaming the config file and running any command that requires it.
+
+**Acceptance Scenarios**:
+
+1. **Given** no config file exists at the default or specified path, **When** the user runs `dbtoon query -P dev "SELECT 1"`, **Then** the system displays an error message directing the user to run `dbtoon init`.
+2. **Given** no config file exists, **When** the user runs `dbtoon profile list`, **Then** the same helpful error is shown.
+
+---
+
+### User Story 6 - Config Resolution Hierarchy (Priority: P2)
+
+Configuration values are resolved in a defined priority order: CLI flags override TOML profile values, which override TOML defaults, which override Databricks standard env vars. A `$VAR` reference to an unset variable is an error, not a fallthrough.
+
+**Why this priority**: Correct resolution order is essential for predictable behavior but relies on the config and profile infrastructure being in place first.
+
+**Independent Test**: Can be tested by setting values at different levels of the hierarchy and verifying the correct value is used for query execution.
+
+**Acceptance Scenarios**:
+
+1. **Given** a profile sets `row_limit = 500` and the user passes `--limit 10`, **When** the query runs, **Then** the limit is 10 (CLI flag wins).
+2. **Given** the `[defaults]` section sets `timeout = 60` and the profile does not set `timeout`, **When** the query runs, **Then** the timeout is 60 (defaults apply).
+3. **Given** a profile sets `host = "$DATABRICKS_HOST"` and the env var is not set, **When** the user tries to use the profile, **Then** an error is raised indicating the env var is unset.
+4. **Given** no profile or default sets `catalog`, and `DATABRICKS_CATALOG` is set, **When** a Databricks query runs, **Then** the env var value is used as the lowest-priority fallback.
+
+---
+
+### User Story 7 - Removal of Legacy Commands and Env Vars (Priority: P2)
+
+The `exec-read` and `exec-write` subcommands, all connection-identity flags on query commands, all `DBTOON_*` environment variables, and the macOS `~/Library/` config path are removed.
+
+**Why this priority**: Cleanup is necessary to avoid confusion, but depends on the new commands being in place.
+
+**Independent Test**: Can be tested by verifying that removed commands, flags, and env vars produce appropriate errors or are simply not recognized.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new CLI is installed, **When** the user runs `dbtoon exec-read "SELECT 1"`, **Then** clap rejects it as an unrecognized subcommand.
+2. **Given** the new CLI is installed, **When** the user passes `--server` to `dbtoon query`, **Then** clap rejects it as an unrecognized flag.
+3. **Given** `DBTOON_SERVER` env var is set, **When** any dbtoon command runs, **Then** the env var is ignored (no effect on behavior).
+
+---
+
+### User Story 8 - Updated Documentation (Priority: P3)
+
+The README and CLI help text are updated to reflect the new command structure, profile-based workflow, and removal of legacy features.
+
+**Why this priority**: Documentation is important but does not block functionality.
+
+**Independent Test**: Can be tested by reviewing the README content and running `dbtoon --help` and `dbtoon query --help` to verify output matches the new structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new CLI, **When** the user runs `dbtoon --help`, **Then** the output lists `init`, `query`, `profile`, `warehouse`, and `update` as commands (no `exec-read` or `exec-write`).
+2. **Given** the new CLI, **When** the user runs `dbtoon query --help`, **Then** the output shows `-P` as required, shows `-d`/`--database`/`--catalog`/`-s`/`--schema` overrides, and does not show connection-identity flags.
+3. **Given** the README, **When** a new user reads it, **Then** it shows `dbtoon init` as the first step, uses `query -P <profile>` in all examples, and documents only Databricks standard env vars.
+
+---
+
+### Edge Cases
+
+- What happens when a user runs `dbtoon init` and the `~/.config/dbtoon/` directory does not exist? The system creates the directory tree.
+- What happens when a user tries to create a profile with a name that already exists? The system rejects it with an error.
+- What happens when `--database` and `--catalog` are both passed to `query`? They are true aliases for a single internal field (`catalog`). Clap enforces mutual exclusivity via a conflict group — passing both is a clap-level error.
+- What happens when `dbtoon init` is run but the config directory is not writable? The system reports a clear file-system error.
+- What happens when `profile edit` tries to set a field that is not valid for the profile's backend? The system rejects it with an error listing valid fields. Valid fields are derived from the existing Rust connection structs per backend.
+- What happens when `profile test` is run on a profile with missing required fields? The system reports which fields are missing before attempting connection. The connectivity check establishes a connection only (no query executed).
+- What happens when a profile value starts with `$` but the env var doesn't exist? The system errors with a message naming the unset variable. There is no fallthrough to a literal interpretation.
+- What happens when a user needs a literal value starting with `$`? They use `$$` as an escape (e.g., `host = "$$pecial"` resolves to `$pecial`).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `dbtoon init` command that creates a config file at `~/.config/dbtoon/config.toml` with a `[defaults]` section and example profiles.
+- **FR-002**: System MUST detect Databricks standard env vars during `init` and auto-populate the Databricks profile with `$VAR` references (e.g., `host = "$DATABRICKS_HOST"`) when any are found.
+- **FR-003**: System MUST provide a unified `dbtoon query` command that replaces `exec-read` and `exec-write`, requiring `-P <PROFILE>` for connection selection.
+- **FR-004**: System MUST support query-level overrides via `-d`/`--database`/`--catalog` (true aliases for a single `catalog` field, mutually exclusive) and `-s`/`--schema` flags that do not modify the profile.
+- **FR-005**: System MUST support `--allow-write` to bypass read-only safety validation on the `query` command.
+- **FR-006**: System MUST support `--no-limit` to disable any configured row limit.
+- **FR-007**: System MUST support `-l`/`--limit` and `-t`/`--timeout` to override profile/default values.
+- **FR-008**: System MUST provide `profile create` with `--backend` and optional `--set key=value` flags, generating `$VAR` defaults appropriate to the backend when no `--set` flags are provided.
+- **FR-009**: System MUST provide `profile edit` to update, add, or remove fields on an existing profile. Fields can be removed via `--set key=` (empty value) or `--unset key`. Both `profile create --set` and `profile edit --set` support the same syntax.
+- **FR-010**: System MUST provide `profile show` that displays resolved config values with credential masking and unset-env-var warnings. For `$VAR` references, show the env var name, the resolved value (masked by default), and a warning if unset.
+- **FR-011**: System MUST provide `profile list` to list all configured profiles.
+- **FR-012**: System MUST provide `profile test` that validates required fields are present, then attempts to establish a backend connection (no query executed) and reports success or the specific connection failure.
+- **FR-013**: System MUST provide `profile delete` to remove a profile from config.
+- **FR-014**: System MUST provide `profile rename` to rename a profile in config.
+- **FR-015**: System MUST update `warehouse list` to use `-P <PROFILE>` for connection details.
+- **FR-016**: System MUST resolve configuration in priority order: CLI flags > TOML profile > TOML defaults > Databricks standard env vars.
+- **FR-017**: System MUST resolve profile string values starting with `$` as environment variable references. If the referenced env var is unset, the system MUST error (no fallthrough). A leading `$$` escapes to a literal `$`.
+- **FR-018**: System MUST remove `exec-read` and `exec-write` subcommands.
+- **FR-019**: System MUST remove all connection-identity flags from `query` and `warehouse list`.
+- **FR-020**: System MUST remove all `DBTOON_*` environment variables.
+- **FR-021**: System MUST use `~/.config/dbtoon/` as the config path on all platforms including macOS.
+- **FR-022**: System MUST display a helpful error directing the user to `dbtoon init` when a required config file is missing.
+- **FR-023**: System MUST support `-c`/`--config`, `-v`/`--verbose`, and `--show-secrets` as global flags on all commands.
+- **FR-024**: System MUST update the README to reflect the new CLI structure.
+- **FR-025**: System MUST update all `--help` output to reflect the new command structure.
+
+### Key Entities
+
+- **Config File**: TOML file at `~/.config/dbtoon/config.toml` containing defaults and profiles. Created by `init`, modified by `profile` subcommands.
+- **Profile**: A named connection configuration within the config file. Contains backend type and connection fields. Field values may be literals or `$VAR` env-var references resolved at use time.
+- **Defaults**: Global settings (`row_limit`, `timeout`, `verbose`, `allow_write`) that apply when not overridden by profile or CLI flags.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can go from install to first query in under 3 commands (`init`, optionally `profile create`, `query`).
+- **SC-002**: All existing query functionality (read, write, output formats, row limits, timeouts) is accessible through the single `query` command.
+- **SC-003**: Users can manage all connection details without editing the config file manually (via `profile` subcommands).
+- **SC-004**: Users can switch between database connections by changing only the `-P` flag, without re-specifying connection details.
+- **SC-005**: The config resolution hierarchy (CLI > profile > defaults > env vars) produces predictable, documented results in all cases.
+- **SC-006**: All removed commands and flags are cleanly removed (no migration shims; clap rejects them as unrecognized).
+- **SC-007**: Zero `DBTOON_*` environment variables are recognized by the system; only Databricks standard vars are used as lowest-priority fallbacks.
+
+## Assumptions
+
+- The existing query execution logic, output formatting, and write-query detection remain unchanged in behavior — only how connection details reach them changes.
+- Profile names are case-sensitive and must be valid TOML key names.
+- The `dbtoon init` command will not overwrite an existing config file (safe re-runs).
+- The `--set` syntax for `profile create`/`edit` uses simple `key=value` pairs with no nested structures.
+- Credential masking behavior (via `secrecy` crate) is retained as-is; `--show-secrets` globally disables it.
+- The `$VAR` resolution applies only to string-typed profile fields. Numeric and boolean fields (e.g., `windows_auth = true`) are always literals.

--- a/specs/009-simplify-cli-ui/tasks.md
+++ b/specs/009-simplify-cli-ui/tasks.md
@@ -23,9 +23,9 @@
 
 **Purpose**: Dependency changes and new module scaffolding
 
-- [ ] T001 Add `toml_edit = "0.25"` and remove `directories` from `Cargo.toml`
-- [ ] T002 [P] Create empty `src/init.rs` with module doc comment, add `pub mod init` to `src/lib.rs`
-- [ ] T003 [P] Create empty `src/profile.rs` with module doc comment, add `pub mod profile` to `src/lib.rs`
+- [X] T001 Add `toml_edit = "0.25"` and remove `directories` from `Cargo.toml`
+- [X] T002 [P] Create empty `src/init.rs` with module doc comment, add `pub mod init` to `src/lib.rs`
+- [X] T003 [P] Create empty `src/profile.rs` with module doc comment, add `pub mod profile` to `src/lib.rs`
 
 ---
 
@@ -39,18 +39,18 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T004 [P] Write unit tests for `default_config_path()` (HOME-based, no `directories` crate) in `tests/unit/config_test.rs`
-- [ ] T005 [P] Write unit tests for `resolve_env_var()` — literal passthrough, `$VAR` resolution, `$$` escape, unset var error — in `tests/unit/config_test.rs`
-- [ ] T006 [P] Write CLI parsing tests for new command structure (init, query -P, profile subcommands, warehouse list -P, global flags including `-c` custom config path) in `tests/unit/cli_test.rs`
-- [ ] T007 [P] Write test for config-missing error message directing user to `dbtoon init` in `tests/unit/config_test.rs`
+- [X] T004 [P] Write unit tests for `default_config_path()` (HOME-based, no `directories` crate) in `tests/unit/config_test.rs`
+- [X] T005 [P] Write unit tests for `resolve_env_var()` — literal passthrough, `$VAR` resolution, `$$` escape, unset var error — in `tests/unit/config_test.rs`
+- [X] T006 [P] Write CLI parsing tests for new command structure (init, query -P, profile subcommands, warehouse list -P, global flags including `-c` custom config path) in `tests/unit/cli_test.rs`
+- [X] T007 [P] Write test for config-missing error message directing user to `dbtoon init` in `tests/unit/config_test.rs`
 
 ### Implementation for Foundational
 
-- [ ] T008 Replace `directories::ProjectDirs` with `HOME`-based `default_config_path()` in `src/config.rs` (R3)
-- [ ] T009 [P] Implement `resolve_env_var()`, `resolve_profile_string()`, `resolve_profile_secret()` in `src/config.rs` (R2)
-- [ ] T010 Restructure `Command` enum in `src/cli.rs` — replace `ExecRead`/`ExecWrite`/`ListWarehouses` with `Init`/`Query`/`Profile`/`Warehouse` per CLI contract; add `QueryArgs`, `ProfileCommand`, `WarehouseCommand` structs with all flags/args
-- [ ] T011 Implement config-missing check: when config file not found, emit error directing user to `dbtoon init` in `src/config.rs`
-- [ ] T012 Remove all `DBTOON_*` `env` attributes from clap structs in `src/cli.rs` and remove `DBTOON_*` env-var reads from `src/config.rs`
+- [X] T008 Replace `directories::ProjectDirs` with `HOME`-based `default_config_path()` in `src/config.rs` (R3)
+- [X] T009 [P] Implement `resolve_env_var()`, `resolve_profile_string()`, `resolve_profile_secret()` in `src/config.rs` (R2)
+- [X] T010 Restructure `Command` enum in `src/cli.rs` — replace `ExecRead`/`ExecWrite`/`ListWarehouses` with `Init`/`Query`/`Profile`/`Warehouse` per CLI contract; add `QueryArgs`, `ProfileCommand`, `WarehouseCommand` structs with all flags/args
+- [X] T011 Implement config-missing check: when config file not found, emit error directing user to `dbtoon init` in `src/config.rs`
+- [X] T012 Remove all `DBTOON_*` `env` attributes from clap structs in `src/cli.rs` and remove `DBTOON_*` env-var reads from `src/config.rs`
 
 **Checkpoint**: Foundation ready — `cargo test` passes, CLI parses new commands (handlers may still be `todo!()`), `$VAR` resolution works, config path uses HOME
 
@@ -66,13 +66,13 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T013 [P] [US1] Write unit tests for init template generation (default template, env-var-detected template, directory creation, unwritable directory error) in `tests/unit/init_test.rs`
-- [ ] T014 [P] [US1] Write test for `dbtoon init` when config already exists (should warn, not overwrite) in `tests/unit/init_test.rs`
+- [X] T013 [P] [US1] Write unit tests for init template generation (default template, env-var-detected template, directory creation, unwritable directory error) in `tests/unit/init_test.rs`
+- [X] T014 [P] [US1] Write test for `dbtoon init` when config already exists (should warn, not overwrite) in `tests/unit/init_test.rs`
 
 ### Implementation for User Story 1
 
-- [ ] T015 [US1] Implement `dbtoon init` logic in `src/init.rs`: template generation, Databricks env var detection, directory creation, already-exists guard (R5)
-- [ ] T016 [US1] Wire `Init` command dispatch in `src/main.rs` to call init logic
+- [X] T015 [US1] Implement `dbtoon init` logic in `src/init.rs`: template generation, Databricks env var detection, directory creation, already-exists guard (R5)
+- [X] T016 [US1] Wire `Init` command dispatch in `src/main.rs` to call init logic
 
 **Checkpoint**: `dbtoon init` works end-to-end in a temp directory
 
@@ -88,16 +88,16 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T017 [P] [US2] Write unit tests for profile loading and config resolution (CLI > profile > defaults > Databricks env fallback) in `tests/unit/config_test.rs`
-- [ ] T018 [P] [US2] Write tests for query input conflict (positional SQL vs `-f`), `--database`/`--catalog` mutual exclusivity, `--no-limit` behavior in `tests/unit/cli_test.rs`
-- [ ] T019 [P] [US2] Write test for `--allow-write` flag gating write queries in `tests/unit/cli_test.rs`
+- [X] T017 [P] [US2] Write unit tests for profile loading and config resolution (CLI > profile > defaults > Databricks env fallback) in `tests/unit/config_test.rs`
+- [X] T018 [P] [US2] Write tests for query input conflict (positional SQL vs `-f`), `--database`/`--catalog` mutual exclusivity, `--no-limit` behavior in `tests/unit/cli_test.rs`
+- [X] T019 [P] [US2] Write test for `--allow-write` flag gating write queries in `tests/unit/cli_test.rs`
 
 ### Implementation for User Story 2
 
-- [ ] T020 [US2] Implement profile loading from TOML config — deserialize `[profiles.<name>]`, resolve `$VAR` fields, apply `[defaults]` fallback in `src/config.rs`
-- [ ] T021 [US2] Implement config resolution hierarchy: CLI flags > profile > defaults > Databricks env vars in `src/config.rs`
-- [ ] T022 [US2] Wire `Query` command dispatch in `src/main.rs` — connect `QueryArgs` to existing query execution logic (backend dispatch, output formatting, write validation)
-- [ ] T023 [US2] Handle `-f`/`--file` SQL input, `--no-limit`, `--limit`, `--timeout`, `--database`/`--catalog`/`--schema` overrides in `src/main.rs`
+- [X] T020 [US2] Implement profile loading from TOML config — deserialize `[profiles.<name>]`, resolve `$VAR` fields, apply `[defaults]` fallback in `src/config.rs`
+- [X] T021 [US2] Implement config resolution hierarchy: CLI flags > profile > defaults > Databricks env vars in `src/config.rs`
+- [X] T022 [US2] Wire `Query` command dispatch in `src/main.rs` — connect `QueryArgs` to existing query execution logic (backend dispatch, output formatting, write validation)
+- [X] T023 [US2] Handle `-f`/`--file` SQL input, `--no-limit`, `--limit`, `--timeout`, `--database`/`--catalog`/`--schema` overrides in `src/main.rs`
 
 **Checkpoint**: `dbtoon query -P dev "SELECT 1"` works with a manually-created config file; all override flags function correctly
 
@@ -113,19 +113,19 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T024 [P] [US3] Write tests for `profile create` — new profile with `$VAR` defaults, `--set` overrides, duplicate name rejection, field validation per backend in `tests/unit/profile_test.rs`
-- [ ] T025 [P] [US3] Write tests for `profile edit` — `--set key=value`, `--set key=` removal, `--unset key`, invalid field rejection in `tests/unit/profile_test.rs`
-- [ ] T026 [P] [US3] Write tests for `profile show` (resolved values, masking, `--show-secrets` reveals masked values, unset env-var warning), `profile list`, `profile delete`, `profile rename` in `tests/unit/profile_test.rs`
+- [X] T024 [P] [US3] Write tests for `profile create` — new profile with `$VAR` defaults, `--set` overrides, duplicate name rejection, field validation per backend in `tests/unit/profile_test.rs`
+- [X] T025 [P] [US3] Write tests for `profile edit` — `--set key=value`, `--set key=` removal, `--unset key`, invalid field rejection in `tests/unit/profile_test.rs`
+- [X] T026 [P] [US3] Write tests for `profile show` (resolved values, masking, `--show-secrets` reveals masked values, unset env-var warning), `profile list`, `profile delete`, `profile rename` in `tests/unit/profile_test.rs`
 
 ### Implementation for User Story 3
 
-- [ ] T027 [US3] Implement `profile create` in `src/profile.rs` — add `[profiles.<name>]` via `toml_edit`, generate backend-appropriate `$VAR` defaults, apply `--set` overrides, validate fields per backend (R1, R4)
-- [ ] T028 [US3] Implement `profile edit` in `src/profile.rs` — `--set key=value`, `--set key=` removal, `--unset key` removal via `toml_edit` (R1)
-- [ ] T029 [P] [US3] Implement `profile show` in `src/profile.rs` — display resolved values with credential masking, show `$VAR` name + resolved value, warn on unset env vars
-- [ ] T030 [P] [US3] Implement `profile list` in `src/profile.rs` — enumerate `[profiles.*]` keys from config
-- [ ] T031 [P] [US3] Implement `profile delete` in `src/profile.rs` — remove `[profiles.<name>]` via `toml_edit`
-- [ ] T032 [P] [US3] Implement `profile rename` in `src/profile.rs` — rename key in `[profiles]` table via `toml_edit`, preserve all fields
-- [ ] T033 [US3] Wire all `Profile` subcommand dispatches in `src/main.rs`
+- [X] T027 [US3] Implement `profile create` in `src/profile.rs` — add `[profiles.<name>]` via `toml_edit`, generate backend-appropriate `$VAR` defaults, apply `--set` overrides, validate fields per backend (R1, R4)
+- [X] T028 [US3] Implement `profile edit` in `src/profile.rs` — `--set key=value`, `--set key=` removal, `--unset key` removal via `toml_edit` (R1)
+- [X] T029 [P] [US3] Implement `profile show` in `src/profile.rs` — display resolved values with credential masking, show `$VAR` name + resolved value, warn on unset env vars
+- [X] T030 [P] [US3] Implement `profile list` in `src/profile.rs` — enumerate `[profiles.*]` keys from config
+- [X] T031 [P] [US3] Implement `profile delete` in `src/profile.rs` — remove `[profiles.<name>]` via `toml_edit`
+- [X] T032 [P] [US3] Implement `profile rename` in `src/profile.rs` — rename key in `[profiles]` table via `toml_edit`, preserve all fields
+- [X] T033 [US3] Wire all `Profile` subcommand dispatches in `src/main.rs`
 
 **Checkpoint**: Full profile CRUD works; config file comments/formatting preserved across edits
 
@@ -141,11 +141,11 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T034 [US4] Write test for `warehouse list` requiring `-P` flag and rejecting legacy `--host`/`--token` flags in `tests/unit/cli_test.rs`
+- [X] T034 [US4] Write test for `warehouse list` requiring `-P` flag and rejecting legacy `--host`/`--token` flags in `tests/unit/cli_test.rs`
 
 ### Implementation for User Story 4
 
-- [ ] T035 [US4] Wire `Warehouse` command dispatch in `src/main.rs` — connect `warehouse list -P <profile>` to existing warehouse listing logic
+- [X] T035 [US4] Wire `Warehouse` command dispatch in `src/main.rs` — connect `warehouse list -P <profile>` to existing warehouse listing logic
 
 **Checkpoint**: `dbtoon warehouse list -P dbx` works with a configured Databricks profile
 
@@ -161,11 +161,11 @@
 
 ### Tests for User Story 5
 
-- [ ] T036 [US5] Write integration test verifying `query`, `profile list`, and `warehouse list` all produce the "run dbtoon init" error when config is missing in `tests/unit/config_test.rs`
+- [X] T036 [US5] Write integration test verifying `query`, `profile list`, and `warehouse list` all produce the "run dbtoon init" error when config is missing in `tests/unit/config_test.rs`
 
 ### Implementation for User Story 5
 
-- [ ] T037 [US5] Ensure config-missing guard is applied in all command dispatch paths (query, profile *, warehouse) in `src/main.rs`
+- [X] T037 [US5] Ensure config-missing guard is applied in all command dispatch paths (query, profile *, warehouse) in `src/main.rs`
 
 **Checkpoint**: All config-dependent commands show the init hint when config is absent
 
@@ -181,13 +181,13 @@
 
 ### Tests for User Story 6
 
-- [ ] T038 [P] [US6] Write integration tests for full resolution hierarchy — CLI override wins, profile wins over defaults, defaults win over Databricks env, `$VAR` to unset var errors in `tests/unit/config_test.rs`
-- [ ] T039 [P] [US6] Write test for Databricks standard env vars as lowest-priority fallback (e.g., `DATABRICKS_CATALOG` used when no profile/default sets catalog) in `tests/unit/config_test.rs`
+- [X] T038 [P] [US6] Write integration tests for full resolution hierarchy — CLI override wins, profile wins over defaults, defaults win over Databricks env, `$VAR` to unset var errors in `tests/unit/config_test.rs`
+- [X] T039 [P] [US6] Write test for Databricks standard env vars as lowest-priority fallback (e.g., `DATABRICKS_CATALOG` used when no profile/default sets catalog) in `tests/unit/config_test.rs`
 
 ### Implementation for User Story 6
 
-- [ ] T040 [US6] Implement Databricks standard env-var fallback (lowest priority) for `host`, `token`, `warehouse_id`, `catalog`, `schema` in `src/config.rs`
-- [ ] T041 [US6] Verify and fix precedence: CLI > profile > defaults > Databricks env in `src/config.rs` and `src/main.rs`
+- [X] T040 [US6] Implement Databricks standard env-var fallback (lowest priority) for `host`, `token`, `warehouse_id`, `catalog`, `schema` in `src/config.rs`
+- [X] T041 [US6] Verify and fix precedence: CLI > profile > defaults > Databricks env in `src/config.rs` and `src/main.rs`
 
 **Checkpoint**: All 4 resolution levels work with correct precedence; unset `$VAR` references error cleanly
 
@@ -203,11 +203,11 @@
 
 ### Tests for User Story 7
 
-- [ ] T042 [US7] Write tests verifying `exec-read` and `exec-write` are unrecognized subcommands, `--server`/`--host`/`--token` etc. are rejected on `query`, and `DBTOON_*` env vars have no effect in `tests/unit/cli_test.rs`
+- [X] T042 [US7] Write tests verifying `exec-read` and `exec-write` are unrecognized subcommands, `--server`/`--host`/`--token` etc. are rejected on `query`, and `DBTOON_*` env vars have no effect in `tests/unit/cli_test.rs`
 
 ### Implementation for User Story 7
 
-- [ ] T043 [US7] Audit all source files to verify T010/T012 completeness — confirm zero remaining legacy command, flag, or env-var references
+- [X] T043 [US7] Audit all source files to verify T010/T012 completeness — confirm zero remaining legacy command, flag, or env-var references
 
 **Checkpoint**: Zero legacy CLI surface remains; clap rejects all removed commands/flags
 
@@ -219,8 +219,8 @@
 
 **Independent Test**: Review README content and run `dbtoon --help`, `dbtoon query --help` to verify
 
-- [ ] T045 [US8] Update README.md — show `dbtoon init` as first step, use `query -P <profile>` in all examples, document Databricks standard env vars only, remove all `exec-read`/`exec-write`/`DBTOON_*` references
-- [ ] T046 [US8] Review and update all clap `about`/`long_about`/`help` strings in `src/cli.rs` to reflect new structure
+- [X] T045 [US8] Update README.md — show `dbtoon init` as first step, use `query -P <profile>` in all examples, document Databricks standard env vars only, remove all `exec-read`/`exec-write`/`DBTOON_*` references
+- [X] T046 [US8] Review and update all clap `about`/`long_about`/`help` strings in `src/cli.rs` to reflect new structure
 
 **Checkpoint**: README and help text match the new CLI contract
 
@@ -234,12 +234,12 @@
 
 ### Tests for Profile Test
 
-- [ ] T047 [US3] Write test for `profile test` — missing required fields error, connectivity attempt in `tests/unit/profile_test.rs`
+- [X] T047 [US3] Write test for `profile test` — missing required fields error, connectivity attempt in `tests/unit/profile_test.rs`
 
 ### Implementation for Profile Test
 
-- [ ] T048 [US3] Implement `profile test` in `src/profile.rs` — validate required fields, attempt backend connection, report result
-- [ ] T049 [US3] Wire `profile test` dispatch in `src/main.rs`
+- [X] T048 [US3] Implement `profile test` in `src/profile.rs` — validate required fields, attempt backend connection, report result
+- [X] T049 [US3] Wire `profile test` dispatch in `src/main.rs`
 
 **Checkpoint**: `dbtoon profile test mydb` reports connection success or specific failure
 
@@ -249,10 +249,10 @@
 
 **Purpose**: Final validation, cleanup, and cross-cutting improvements
 
-- [ ] T050 Run full `cargo test` suite and fix any failures
-- [ ] T051 Run `cargo clippy` and resolve all warnings
-- [ ] T052 [P] Remove unused imports, dead code, and `todo!()` stubs across all source files
-- [ ] T053 Run quickstart.md validation — execute the implementation order steps end-to-end
+- [X] T050 Run full `cargo test` suite and fix any failures
+- [X] T051 Run `cargo clippy` and resolve all warnings
+- [X] T052 [P] Remove unused imports, dead code, and `todo!()` stubs across all source files
+- [X] T053 Run quickstart.md validation — execute the implementation order steps end-to-end
 
 ---
 

--- a/specs/009-simplify-cli-ui/tasks.md
+++ b/specs/009-simplify-cli-ui/tasks.md
@@ -1,0 +1,359 @@
+# Tasks: Simplify CLI Interface
+
+**Input**: Design documents from `/specs/009-simplify-cli-ui/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: TDD is required per CLAUDE.md. Tests are written before implementation in each phase.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: `src/`, `tests/` at repository root
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Dependency changes and new module scaffolding
+
+- [ ] T001 Add `toml_edit = "0.25"` and remove `directories` from `Cargo.toml`
+- [ ] T002 [P] Create empty `src/init.rs` with module doc comment, add `pub mod init` to `src/lib.rs`
+- [ ] T003 [P] Create empty `src/profile.rs` with module doc comment, add `pub mod profile` to `src/lib.rs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story — config path, `$VAR` resolution, CLI restructure, config-missing error
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+### Tests for Foundational
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T004 [P] Write unit tests for `default_config_path()` (HOME-based, no `directories` crate) in `tests/unit/config_test.rs`
+- [ ] T005 [P] Write unit tests for `resolve_env_var()` — literal passthrough, `$VAR` resolution, `$$` escape, unset var error — in `tests/unit/config_test.rs`
+- [ ] T006 [P] Write CLI parsing tests for new command structure (init, query -P, profile subcommands, warehouse list -P, global flags including `-c` custom config path) in `tests/unit/cli_test.rs`
+- [ ] T007 [P] Write test for config-missing error message directing user to `dbtoon init` in `tests/unit/config_test.rs`
+
+### Implementation for Foundational
+
+- [ ] T008 Replace `directories::ProjectDirs` with `HOME`-based `default_config_path()` in `src/config.rs` (R3)
+- [ ] T009 [P] Implement `resolve_env_var()`, `resolve_profile_string()`, `resolve_profile_secret()` in `src/config.rs` (R2)
+- [ ] T010 Restructure `Command` enum in `src/cli.rs` — replace `ExecRead`/`ExecWrite`/`ListWarehouses` with `Init`/`Query`/`Profile`/`Warehouse` per CLI contract; add `QueryArgs`, `ProfileCommand`, `WarehouseCommand` structs with all flags/args
+- [ ] T011 Implement config-missing check: when config file not found, emit error directing user to `dbtoon init` in `src/config.rs`
+- [ ] T012 Remove all `DBTOON_*` `env` attributes from clap structs in `src/cli.rs` and remove `DBTOON_*` env-var reads from `src/config.rs`
+
+**Checkpoint**: Foundation ready — `cargo test` passes, CLI parses new commands (handlers may still be `todo!()`), `$VAR` resolution works, config path uses HOME
+
+---
+
+## Phase 3: User Story 1 — First-Time Setup with Config Initialization (Priority: P1) 🎯 MVP
+
+**Goal**: `dbtoon init` creates config file with defaults and example profiles; detects Databricks env vars
+
+**Independent Test**: Run `dbtoon init` in a temp dir and verify config file contents and stdout output
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T013 [P] [US1] Write unit tests for init template generation (default template, env-var-detected template, directory creation, unwritable directory error) in `tests/unit/init_test.rs`
+- [ ] T014 [P] [US1] Write test for `dbtoon init` when config already exists (should warn, not overwrite) in `tests/unit/init_test.rs`
+
+### Implementation for User Story 1
+
+- [ ] T015 [US1] Implement `dbtoon init` logic in `src/init.rs`: template generation, Databricks env var detection, directory creation, already-exists guard (R5)
+- [ ] T016 [US1] Wire `Init` command dispatch in `src/main.rs` to call init logic
+
+**Checkpoint**: `dbtoon init` works end-to-end in a temp directory
+
+---
+
+## Phase 4: User Story 2 — Execute a Query Using a Profile (Priority: P1)
+
+**Goal**: `dbtoon query -P <profile> "SQL"` executes queries using profile connection settings with CLI overrides
+
+**Independent Test**: Create a profile manually in a temp config, run `dbtoon query -P <profile> "SELECT 1"` and verify execution/error handling
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T017 [P] [US2] Write unit tests for profile loading and config resolution (CLI > profile > defaults > Databricks env fallback) in `tests/unit/config_test.rs`
+- [ ] T018 [P] [US2] Write tests for query input conflict (positional SQL vs `-f`), `--database`/`--catalog` mutual exclusivity, `--no-limit` behavior in `tests/unit/cli_test.rs`
+- [ ] T019 [P] [US2] Write test for `--allow-write` flag gating write queries in `tests/unit/cli_test.rs`
+
+### Implementation for User Story 2
+
+- [ ] T020 [US2] Implement profile loading from TOML config — deserialize `[profiles.<name>]`, resolve `$VAR` fields, apply `[defaults]` fallback in `src/config.rs`
+- [ ] T021 [US2] Implement config resolution hierarchy: CLI flags > profile > defaults > Databricks env vars in `src/config.rs`
+- [ ] T022 [US2] Wire `Query` command dispatch in `src/main.rs` — connect `QueryArgs` to existing query execution logic (backend dispatch, output formatting, write validation)
+- [ ] T023 [US2] Handle `-f`/`--file` SQL input, `--no-limit`, `--limit`, `--timeout`, `--database`/`--catalog`/`--schema` overrides in `src/main.rs`
+
+**Checkpoint**: `dbtoon query -P dev "SELECT 1"` works with a manually-created config file; all override flags function correctly
+
+---
+
+## Phase 5: User Story 3 — Profile Management (Priority: P2)
+
+**Goal**: `profile create/edit/show/list/test/delete/rename` subcommands manage profiles via `toml_edit`
+
+**Independent Test**: Run profile CRUD commands and verify config file is updated correctly
+
+### Tests for User Story 3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T024 [P] [US3] Write tests for `profile create` — new profile with `$VAR` defaults, `--set` overrides, duplicate name rejection, field validation per backend in `tests/unit/profile_test.rs`
+- [ ] T025 [P] [US3] Write tests for `profile edit` — `--set key=value`, `--set key=` removal, `--unset key`, invalid field rejection in `tests/unit/profile_test.rs`
+- [ ] T026 [P] [US3] Write tests for `profile show` (resolved values, masking, `--show-secrets` reveals masked values, unset env-var warning), `profile list`, `profile delete`, `profile rename` in `tests/unit/profile_test.rs`
+
+### Implementation for User Story 3
+
+- [ ] T027 [US3] Implement `profile create` in `src/profile.rs` — add `[profiles.<name>]` via `toml_edit`, generate backend-appropriate `$VAR` defaults, apply `--set` overrides, validate fields per backend (R1, R4)
+- [ ] T028 [US3] Implement `profile edit` in `src/profile.rs` — `--set key=value`, `--set key=` removal, `--unset key` removal via `toml_edit` (R1)
+- [ ] T029 [P] [US3] Implement `profile show` in `src/profile.rs` — display resolved values with credential masking, show `$VAR` name + resolved value, warn on unset env vars
+- [ ] T030 [P] [US3] Implement `profile list` in `src/profile.rs` — enumerate `[profiles.*]` keys from config
+- [ ] T031 [P] [US3] Implement `profile delete` in `src/profile.rs` — remove `[profiles.<name>]` via `toml_edit`
+- [ ] T032 [P] [US3] Implement `profile rename` in `src/profile.rs` — rename key in `[profiles]` table via `toml_edit`, preserve all fields
+- [ ] T033 [US3] Wire all `Profile` subcommand dispatches in `src/main.rs`
+
+**Checkpoint**: Full profile CRUD works; config file comments/formatting preserved across edits
+
+---
+
+## Phase 6: User Story 4 — Warehouse Listing via Profile (Priority: P3)
+
+**Goal**: `dbtoon warehouse list -P <profile>` lists Databricks warehouses using profile connection
+
+**Independent Test**: Run `dbtoon warehouse list -P <databricks-profile>` and verify warehouse list is returned
+
+### Tests for User Story 4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T034 [US4] Write test for `warehouse list` requiring `-P` flag and rejecting legacy `--host`/`--token` flags in `tests/unit/cli_test.rs`
+
+### Implementation for User Story 4
+
+- [ ] T035 [US4] Wire `Warehouse` command dispatch in `src/main.rs` — connect `warehouse list -P <profile>` to existing warehouse listing logic
+
+**Checkpoint**: `dbtoon warehouse list -P dbx` works with a configured Databricks profile
+
+---
+
+## Phase 7: User Story 5 — Config File Requirement Enforcement (Priority: P1)
+
+**Goal**: Commands requiring config (query, profile *, warehouse list) show helpful error directing to `dbtoon init`
+
+**Independent Test**: Delete/rename config file, run any config-dependent command, verify helpful error message
+
+*Note: The config-missing check was implemented in Phase 2 (T011). This phase validates it's wired into all command paths.*
+
+### Tests for User Story 5
+
+- [ ] T036 [US5] Write integration test verifying `query`, `profile list`, and `warehouse list` all produce the "run dbtoon init" error when config is missing in `tests/unit/config_test.rs`
+
+### Implementation for User Story 5
+
+- [ ] T037 [US5] Ensure config-missing guard is applied in all command dispatch paths (query, profile *, warehouse) in `src/main.rs`
+
+**Checkpoint**: All config-dependent commands show the init hint when config is absent
+
+---
+
+## Phase 8: User Story 6 — Config Resolution Hierarchy (Priority: P2)
+
+**Goal**: CLI flags > TOML profile > TOML defaults > Databricks standard env vars, with `$VAR` error on unset
+
+**Independent Test**: Set values at multiple hierarchy levels and verify correct precedence
+
+*Note: Core resolution was implemented in Phase 4 (T021). This phase adds integration-level validation and Databricks env-var fallback.*
+
+### Tests for User Story 6
+
+- [ ] T038 [P] [US6] Write integration tests for full resolution hierarchy — CLI override wins, profile wins over defaults, defaults win over Databricks env, `$VAR` to unset var errors in `tests/unit/config_test.rs`
+- [ ] T039 [P] [US6] Write test for Databricks standard env vars as lowest-priority fallback (e.g., `DATABRICKS_CATALOG` used when no profile/default sets catalog) in `tests/unit/config_test.rs`
+
+### Implementation for User Story 6
+
+- [ ] T040 [US6] Implement Databricks standard env-var fallback (lowest priority) for `host`, `token`, `warehouse_id`, `catalog`, `schema` in `src/config.rs`
+- [ ] T041 [US6] Verify and fix precedence: CLI > profile > defaults > Databricks env in `src/config.rs` and `src/main.rs`
+
+**Checkpoint**: All 4 resolution levels work with correct precedence; unset `$VAR` references error cleanly
+
+---
+
+## Phase 9: User Story 7 — Removal of Legacy Commands and Env Vars (Priority: P2)
+
+**Goal**: `exec-read`, `exec-write`, connection-identity flags, and `DBTOON_*` env vars are fully removed
+
+**Independent Test**: Run removed commands/flags and verify clap rejects them
+
+*Note: Env var removal was done in T012; CLI restructure in T010 already removed old commands. This phase validates completeness.*
+
+### Tests for User Story 7
+
+- [ ] T042 [US7] Write tests verifying `exec-read` and `exec-write` are unrecognized subcommands, `--server`/`--host`/`--token` etc. are rejected on `query`, and `DBTOON_*` env vars have no effect in `tests/unit/cli_test.rs`
+
+### Implementation for User Story 7
+
+- [ ] T043 [US7] Audit all source files to verify T010/T012 completeness — confirm zero remaining legacy command, flag, or env-var references
+
+**Checkpoint**: Zero legacy CLI surface remains; clap rejects all removed commands/flags
+
+---
+
+## Phase 10: User Story 8 — Updated Documentation (Priority: P3)
+
+**Goal**: README and `--help` text reflect new command structure
+
+**Independent Test**: Review README content and run `dbtoon --help`, `dbtoon query --help` to verify
+
+- [ ] T045 [US8] Update README.md — show `dbtoon init` as first step, use `query -P <profile>` in all examples, document Databricks standard env vars only, remove all `exec-read`/`exec-write`/`DBTOON_*` references
+- [ ] T046 [US8] Review and update all clap `about`/`long_about`/`help` strings in `src/cli.rs` to reflect new structure
+
+**Checkpoint**: README and help text match the new CLI contract
+
+---
+
+## Phase 11: User Story 3 (cont.) — Profile Test Command (Priority: P2)
+
+**Goal**: `profile test <name>` verifies connectivity and reports success/failure
+
+**Independent Test**: Run `dbtoon profile test <name>` against a configured profile
+
+### Tests for Profile Test
+
+- [ ] T047 [US3] Write test for `profile test` — missing required fields error, connectivity attempt in `tests/unit/profile_test.rs`
+
+### Implementation for Profile Test
+
+- [ ] T048 [US3] Implement `profile test` in `src/profile.rs` — validate required fields, attempt backend connection, report result
+- [ ] T049 [US3] Wire `profile test` dispatch in `src/main.rs`
+
+**Checkpoint**: `dbtoon profile test mydb` reports connection success or specific failure
+
+---
+
+## Phase 12: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, cleanup, and cross-cutting improvements
+
+- [ ] T050 Run full `cargo test` suite and fix any failures
+- [ ] T051 Run `cargo clippy` and resolve all warnings
+- [ ] T052 [P] Remove unused imports, dead code, and `todo!()` stubs across all source files
+- [ ] T053 Run quickstart.md validation — execute the implementation order steps end-to-end
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **US1 Init (Phase 3)**: Depends on Phase 2
+- **US2 Query (Phase 4)**: Depends on Phase 2 (and benefits from US1 for config creation)
+- **US3 Profile (Phase 5)**: Depends on Phase 2
+- **US4 Warehouse (Phase 6)**: Depends on Phase 2 + Phase 4 (query wiring pattern)
+- **US5 Config Enforcement (Phase 7)**: Depends on Phase 2 + Phase 4 + Phase 5 + Phase 6 (all command paths must exist)
+- **US6 Resolution Hierarchy (Phase 8)**: Depends on Phase 4 (profile loading exists)
+- **US7 Legacy Removal (Phase 9)**: Depends on Phase 2 (new CLI in place)
+- **US8 Documentation (Phase 10)**: Depends on all functional phases
+- **Profile Test (Phase 11)**: Depends on Phase 5 (profile infrastructure)
+- **Polish (Phase 12)**: Depends on all prior phases
+
+### User Story Dependencies
+
+- **US1 (Init)**: Independent after Phase 2
+- **US2 (Query)**: Independent after Phase 2; benefits from US1 for easier testing
+- **US3 (Profile CRUD)**: Independent after Phase 2
+- **US4 (Warehouse)**: Depends on query wiring pattern from US2
+- **US5 (Config Enforcement)**: Depends on all command paths existing (US2, US3, US4)
+- **US6 (Resolution)**: Depends on US2 (profile loading infrastructure)
+- **US7 (Legacy Removal)**: Can verify after Phase 2; final audit after all commands wired
+- **US8 (Documentation)**: Depends on all functional stories
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Infrastructure (config/resolution) before command wiring
+- Command wiring before dispatch in main.rs
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T002, T003 (module scaffolding) in parallel
+- T004, T005, T006, T007 (foundational tests) in parallel
+- T009 (env var resolution) parallel with T008 (different functions in same file — careful)
+- T013, T014 (US1 tests) in parallel
+- T017, T018, T019 (US2 tests) in parallel
+- T024, T025, T026 (US3 tests) in parallel
+- T029, T030, T031, T032 (profile show/list/delete/rename) in parallel
+- T038, T039 (US6 tests) in parallel
+- T050, T051, T052 (polish) partially in parallel
+
+---
+
+## Parallel Example: User Story 3 (Profile Management)
+
+```bash
+# Launch all US3 tests together:
+Task: "Write tests for profile create in tests/unit/profile_test.rs" (T024)
+Task: "Write tests for profile edit in tests/unit/profile_test.rs" (T025)
+Task: "Write tests for profile show/list/delete/rename in tests/unit/profile_test.rs" (T026)
+
+# After tests written, launch independent profile operations:
+Task: "Implement profile show in src/profile.rs" (T029)
+Task: "Implement profile list in src/profile.rs" (T030)
+Task: "Implement profile delete in src/profile.rs" (T031)
+Task: "Implement profile rename in src/profile.rs" (T032)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 + 5)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL — blocks all stories)
+3. Complete Phase 3: US1 (Init) — users can create config
+4. Complete Phase 4: US2 (Query) — users can execute queries
+5. **STOP and VALIDATE**: `dbtoon init` → `dbtoon query -P dev "SELECT 1"` works end-to-end
+6. Complete Phase 7: US5 (Config Enforcement) after US3/US4 command paths exist
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready
+2. US1 (Init) → users can bootstrap config
+3. US2 (Query) → core query workflow works
+4. US3 (Profile CRUD) → users can manage profiles without editing TOML
+5. US4 (Warehouse) → warehouse listing via profile
+6. US5 (Config Enforcement) → all command paths guarded (requires US2, US3, US4)
+7. US6 (Resolution) → full config resolution hierarchy
+8. US7 (Legacy Removal) → clean break from old surface
+9. US8 (Documentation) → README reflects new reality
+10. Polish → final quality pass
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- TDD: Write tests, verify they fail, then implement
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- `profile test` is split to Phase 11 because it requires backend connectivity (higher complexity, lower priority within US3)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,15 +5,15 @@ use std::path::PathBuf;
 #[command(name = "dbtoon", about = "Multi-database query CLI with TOON output")]
 pub struct Cli {
     /// Path to config file
-    #[arg(short = 'c', long, global = true, env = "DBTOON_CONFIG")]
+    #[arg(short = 'c', long, global = true)]
     pub config: Option<PathBuf>,
 
     /// Emit diagnostics to stderr
-    #[arg(short = 'v', long, global = true, env = "DBTOON_VERBOSE")]
+    #[arg(short = 'v', long, global = true)]
     pub verbose: bool,
 
     /// Disable credential masking
-    #[arg(long, global = true, env = "DBTOON_SHOW_SECRETS")]
+    #[arg(long, global = true)]
     pub show_secrets: bool,
 
     #[command(subcommand)]
@@ -22,111 +22,152 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Execute a read-only query
-    #[command(name = "exec-read")]
-    ExecRead(ExecArgs),
+    /// Create a config file with defaults and example profiles
+    Init,
 
-    /// Execute a query without read-only validation (requires DBTOON_ALLOW_WRITE=true)
-    #[command(name = "exec-write")]
-    ExecWrite(ExecArgs),
+    /// Execute a SQL query against a profile
+    Query(QueryArgs),
 
-    /// List available Databricks SQL warehouses
-    #[command(name = "list-warehouses")]
-    ListWarehouses(ListWarehousesArgs),
+    /// Manage connection profiles
+    #[command(subcommand)]
+    Profile(ProfileCommand),
+
+    /// Databricks warehouse operations
+    Warehouse(WarehouseArgs),
 
     /// Update dbtoon to the latest release
     Update,
 }
 
 #[derive(Parser, Debug)]
-pub struct ExecArgs {
+pub struct QueryArgs {
     /// SQL query text
+    #[arg(conflicts_with = "file")]
     pub sql: Option<String>,
 
     /// Read SQL from file
-    #[arg(short = 'f', long = "file", conflicts_with = "sql")]
-    pub sql_file: Option<PathBuf>,
+    #[arg(short = 'f', long)]
+    pub file: Option<PathBuf>,
 
-    /// Backend type: sqlserver or databricks
-    #[arg(short = 'b', long, env = "DBTOON_BACKEND")]
-    pub backend: Option<String>,
+    /// Profile name
+    #[arg(short = 'P', long, required = true)]
+    pub profile: String,
 
-    /// SQL Server hostname
-    #[arg(short = 's', long, env = "DBTOON_SERVER")]
-    pub server: Option<String>,
-
-    /// Database name
-    #[arg(short = 'd', long, env = "DBTOON_DATABASE")]
+    /// Override database/catalog
+    #[arg(short = 'd', long, conflicts_with = "catalog")]
     pub database: Option<String>,
 
-    /// SQL Auth username
-    #[arg(short = 'u', long, env = "DBTOON_USERNAME")]
-    pub username: Option<String>,
-
-    /// SQL Auth password
-    #[arg(short = 'p', long, env = "DBTOON_PASSWORD")]
-    pub password: Option<String>,
-
-    /// Use Windows Integrated Auth
-    #[arg(short = 'w', long, env = "DBTOON_WINDOWS_AUTH")]
-    pub windows_auth: bool,
-
-    /// Trust SQL Server certificate (for self-signed/dev instances)
-    #[arg(long, env = "DBTOON_TRUST_SERVER_CERT")]
-    pub trust_server_certificate: bool,
-
-    /// Databricks workspace host
-    #[arg(long, env = "DBTOON_DATABRICKS_HOST")]
-    pub host: Option<String>,
-
-    /// Databricks bearer token
-    #[arg(long, env = "DBTOON_DATABRICKS_TOKEN")]
-    pub token: Option<String>,
-
-    /// Databricks SQL warehouse ID
-    #[arg(long, env = "DBTOON_WAREHOUSE_ID")]
-    pub warehouse: Option<String>,
-
-    /// Databricks catalog
-    #[arg(long, env = "DBTOON_CATALOG")]
+    /// Override catalog (alias for --database)
+    #[arg(long, conflicts_with = "database")]
     pub catalog: Option<String>,
 
-    /// Databricks schema
-    #[arg(long, env = "DBTOON_SCHEMA")]
+    /// Override schema
+    #[arg(short = 's', long)]
     pub schema: Option<String>,
 
-    /// Max rows to return (default: 500)
-    #[arg(short = 'l', long, env = "DBTOON_ROW_LIMIT")]
+    /// Override row limit
+    #[arg(short = 'l', long)]
     pub limit: Option<usize>,
 
     /// Disable row limit
     #[arg(long)]
     pub no_limit: bool,
 
-    /// Query timeout in seconds (default: 60)
-    #[arg(short = 't', long, env = "DBTOON_TIMEOUT")]
+    /// Override timeout in seconds
+    #[arg(short = 't', long)]
     pub timeout: Option<u64>,
 
-    /// Write results to file instead of stdout
+    /// Write results to file instead of stdout (format detected by extension)
     #[arg(short = 'o', long)]
     pub output: Option<PathBuf>,
 
-    /// Config file profile name
-    #[arg(short = 'P', long, env = "DBTOON_PROFILE")]
-    pub profile: Option<String>,
+    /// Bypass read-only safety validation
+    #[arg(long)]
+    pub allow_write: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProfileCommand {
+    /// Create a new connection profile
+    Create(ProfileCreateArgs),
+
+    /// Edit an existing profile
+    Edit(ProfileEditArgs),
+
+    /// Display profile with resolved values
+    Show(ProfileNameArgs),
+
+    /// List all profile names
+    List,
+
+    /// Test connectivity for a profile
+    Test(ProfileNameArgs),
+
+    /// Delete a profile
+    Delete(ProfileNameArgs),
+
+    /// Rename a profile
+    Rename(ProfileRenameArgs),
 }
 
 #[derive(Parser, Debug)]
-pub struct ListWarehousesArgs {
-    /// Databricks workspace host
-    #[arg(long, env = "DBTOON_DATABRICKS_HOST")]
-    pub host: Option<String>,
+pub struct ProfileCreateArgs {
+    /// Profile name
+    pub name: String,
 
-    /// Databricks bearer token
-    #[arg(long, env = "DBTOON_DATABRICKS_TOKEN")]
-    pub token: Option<String>,
+    /// Backend type: databricks or sqlserver
+    #[arg(long, required = true)]
+    pub backend: String,
 
-    /// Config file profile name
-    #[arg(short = 'P', long, env = "DBTOON_PROFILE")]
-    pub profile: Option<String>,
+    /// Set field values (repeatable, e.g., --set host=example.com)
+    #[arg(long = "set", value_name = "KEY=VALUE")]
+    pub set_fields: Vec<String>,
+}
+
+#[derive(Parser, Debug)]
+pub struct ProfileEditArgs {
+    /// Profile name
+    pub name: String,
+
+    /// Set field values (repeatable, e.g., --set host=example.com; --set key= removes field)
+    #[arg(long = "set", value_name = "KEY=VALUE")]
+    pub set_fields: Vec<String>,
+
+    /// Remove fields (repeatable)
+    #[arg(long = "unset", value_name = "KEY")]
+    pub unset_fields: Vec<String>,
+}
+
+#[derive(Parser, Debug)]
+pub struct ProfileNameArgs {
+    /// Profile name
+    pub name: String,
+}
+
+#[derive(Parser, Debug)]
+pub struct ProfileRenameArgs {
+    /// Current profile name
+    pub old: String,
+
+    /// New profile name
+    pub new: String,
+}
+
+#[derive(Parser, Debug)]
+pub struct WarehouseArgs {
+    #[command(subcommand)]
+    pub command: WarehouseCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum WarehouseCommand {
+    /// List available Databricks SQL warehouses
+    List(WarehouseListArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct WarehouseListArgs {
+    /// Databricks profile name
+    #[arg(short = 'P', long, required = true)]
+    pub profile: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
-use crate::cli::{ExecArgs, ListWarehousesArgs};
+use crate::cli::{QueryArgs, WarehouseListArgs};
 use crate::error::DbtoonError;
-use directories::ProjectDirs;
 use secrecy::SecretString;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -49,37 +48,35 @@ pub enum SqlServerAuth {
 // --- TOML config file structs ---
 
 #[derive(Debug, Deserialize, Default)]
-struct TomlConfig {
+pub struct TomlConfig {
     #[serde(default)]
-    defaults: TomlDefaults,
+    pub defaults: TomlDefaults,
     #[serde(default)]
-    profiles: HashMap<String, TomlProfile>,
+    pub profiles: HashMap<String, TomlProfile>,
 }
 
 #[derive(Debug, Deserialize, Default)]
-struct TomlDefaults {
-    row_limit: Option<usize>,
-    timeout: Option<u64>,
-    verbose: Option<bool>,
-    allow_write: Option<bool>,
+pub struct TomlDefaults {
+    pub row_limit: Option<usize>,
+    pub timeout: Option<u64>,
+    pub verbose: Option<bool>,
+    pub allow_write: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
-struct TomlProfile {
-    backend: Option<String>,
-    server: Option<String>,
-    database: Option<String>,
-    username: Option<String>,
-    password: Option<String>,
-    password_env: Option<String>,
-    windows_auth: Option<bool>,
-    trust_server_certificate: Option<bool>,
-    host: Option<String>,
-    token: Option<String>,
-    token_env: Option<String>,
-    warehouse_id: Option<String>,
-    catalog: Option<String>,
-    schema: Option<String>,
+pub struct TomlProfile {
+    pub backend: Option<String>,
+    pub server: Option<String>,
+    pub database: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub windows_auth: Option<bool>,
+    pub trust_server_certificate: Option<bool>,
+    pub host: Option<String>,
+    pub token: Option<String>,
+    pub warehouse_id: Option<String>,
+    pub catalog: Option<String>,
+    pub schema: Option<String>,
 }
 
 /// Filter `Some("")` to `None`. Passes through `None` and non-empty values.
@@ -92,247 +89,266 @@ pub fn env_non_empty(key: &str) -> Option<String> {
     std::env::var(key).ok().filter(|v| !v.is_empty())
 }
 
+/// Return the default config file path: `$HOME/.config/dbtoon/config.toml`.
+pub fn default_config_path() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".config/dbtoon/config.toml"))
+}
+
+/// Resolve a `$VAR` reference to its env var value.
+///
+/// - `$VARNAME` → env var value (error if unset)
+/// - `$$...` → literal `$...` (escape)
+/// - anything else → literal passthrough
+pub fn resolve_env_var(value: &str) -> Result<String, DbtoonError> {
+    if let Some(rest) = value.strip_prefix("$$") {
+        Ok(format!("${}", rest))
+    } else if let Some(var_name) = value.strip_prefix('$') {
+        std::env::var(var_name).map_err(|_| DbtoonError::Config {
+            message: format!("environment variable '{}' is not set", var_name),
+        })
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+/// Resolve an optional string profile field via `$VAR` resolution.
+pub fn resolve_profile_string(value: Option<&str>) -> Result<Option<String>, DbtoonError> {
+    match value {
+        Some(v) => resolve_env_var(v).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Resolve an optional secret profile field via `$VAR` resolution.
+pub fn resolve_profile_secret(value: Option<&str>) -> Result<Option<SecretString>, DbtoonError> {
+    match value {
+        Some(v) => resolve_env_var(v).map(|s| Some(SecretString::from(s))),
+        None => Ok(None),
+    }
+}
+
 /// Config path resolution result — distinguishes explicit vs auto-resolved paths.
 struct ResolvedConfigPath {
     path: PathBuf,
-    /// true if user explicitly specified via --config or DBTOON_CONFIG
-    explicit: bool,
 }
 
-/// Resolve the config file path: --config flag > env var > platform default.
+/// Resolve the config file path: --config flag > platform default.
 fn resolve_config_path(cli_config: Option<&PathBuf>) -> Option<ResolvedConfigPath> {
     if let Some(path) = cli_config {
-        return Some(ResolvedConfigPath { path: path.clone(), explicit: true });
+        return Some(ResolvedConfigPath { path: path.clone() });
     }
-    if let Ok(path) = std::env::var("DBTOON_CONFIG") {
-        return Some(ResolvedConfigPath { path: PathBuf::from(path), explicit: true });
-    }
-    ProjectDirs::from("", "", "dbtoon")
-        .map(|dirs| ResolvedConfigPath {
-            path: dirs.config_dir().join("config.toml"),
-            explicit: false,
-        })
+    default_config_path().map(|path| ResolvedConfigPath { path })
 }
 
 /// Load and parse the TOML config file (if it exists).
-fn load_toml_config(resolved: Option<&ResolvedConfigPath>) -> Result<TomlConfig, DbtoonError> {
-    let resolved = match resolved {
-        Some(r) => r,
+pub fn load_toml_config(resolved: Option<&PathBuf>, explicit: bool) -> Result<TomlConfig, DbtoonError> {
+    let path = match resolved {
+        Some(p) => p,
         None => return Ok(TomlConfig::default()),
     };
 
-    if !resolved.path.exists() {
-        if resolved.explicit {
+    if !path.exists() {
+        if explicit {
             return Err(DbtoonError::Config {
-                message: format!("config file not found: {}", resolved.path.display()),
+                message: format!("config file not found: {}", path.display()),
             });
         }
-        // Auto-resolved path doesn't exist — that's fine
         return Ok(TomlConfig::default());
     }
 
-    let content = std::fs::read_to_string(&resolved.path).map_err(|e| DbtoonError::Config {
-        message: format!("cannot read config file {}: {}", resolved.path.display(), e),
+    let content = std::fs::read_to_string(path).map_err(|e| DbtoonError::Config {
+        message: format!("cannot read config file {}: {}", path.display(), e),
     })?;
 
     toml::from_str(&content).map_err(|e| DbtoonError::Config {
-        message: format!("invalid config file {}: {}", resolved.path.display(), e),
+        message: format!("invalid config file {}: {}", path.display(), e),
     })
 }
 
-/// Resolve a password from direct value, env indirection, or env var.
-fn resolve_secret(
-    direct: Option<&str>,
-    env_key: Option<&str>,
-    fallback_env: &str,
-) -> Option<SecretString> {
-    // Direct value first
-    if let Some(val) = direct
-        && !val.is_empty() {
-            return Some(SecretString::from(val.to_string()));
-        }
-    // Env indirection (e.g., password_env = "MY_SECRET")
-    if let Some(key) = env_key
-        && let Ok(val) = std::env::var(key)
-            && !val.is_empty() {
-                return Some(SecretString::from(val));
+/// Load and parse the TOML config file, erroring if missing (for commands that require it).
+pub fn load_toml_config_required(config_path: Option<&PathBuf>) -> Result<(TomlConfig, PathBuf), DbtoonError> {
+    let resolved = resolve_config_path(config_path);
+    match resolved {
+        Some(r) => {
+            if !r.path.exists() {
+                return Err(DbtoonError::Config {
+                    message: format!(
+                        "config file not found: {}\n\nRun `dbtoon init` to create one.",
+                        r.path.display()
+                    ),
+                });
             }
-    // Fallback env var (e.g., DBTOON_PASSWORD)
-    if let Ok(val) = std::env::var(fallback_env)
-        && !val.is_empty() {
-            return Some(SecretString::from(val));
+            let content = std::fs::read_to_string(&r.path).map_err(|e| DbtoonError::Config {
+                message: format!("cannot read config file {}: {}", r.path.display(), e),
+            })?;
+            let config: TomlConfig = toml::from_str(&content).map_err(|e| DbtoonError::Config {
+                message: format!("invalid config file {}: {}", r.path.display(), e),
+            })?;
+            Ok((config, r.path))
         }
-    None
+        None => Err(DbtoonError::Config {
+            message: "cannot determine config file location (HOME not set)\n\nRun `dbtoon init` to create one.".to_string(),
+        }),
+    }
 }
 
-/// Build AppConfig from exec-read/exec-write CLI args.
-pub fn load_from_exec_args(
-    args: &ExecArgs,
-    verbose: bool,
-    show_secrets: bool,
-    config_path: Option<&PathBuf>,
-) -> Result<AppConfig, DbtoonError> {
-    let resolved_path = resolve_config_path(config_path);
-    let toml_config = load_toml_config(resolved_path.as_ref())?;
+/// Load a named profile from config, with `$VAR` resolution applied to string fields.
+pub fn load_profile(
+    toml_config: &TomlConfig,
+    profile_name: &str,
+) -> Result<TomlProfile, DbtoonError> {
+    toml_config.profiles.get(profile_name).cloned().ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' not found in config file", profile_name),
+    })
+}
 
-    // Load profile if specified
-    let profile = args.profile.as_ref().map(|name| {
-        toml_config.profiles.get(name).cloned().ok_or_else(|| DbtoonError::Config {
-            message: format!("profile '{}' not found in config file", name),
-        })
-    }).transpose()?;
+/// Build a BackendConfig from a resolved profile, applying CLI overrides and Databricks env fallbacks.
+pub fn build_backend_config(
+    profile: &TomlProfile,
+    cli_database: Option<&str>,
+    cli_schema: Option<&str>,
+) -> Result<BackendConfig, DbtoonError> {
+    let backend_str = profile.backend.as_deref().ok_or_else(|| DbtoonError::Config {
+        message: "profile has no 'backend' field".to_string(),
+    })?;
 
-    let profile = profile.unwrap_or_default();
+    match backend_str {
+        "sqlserver" => build_sqlserver_config(profile, cli_database),
+        "databricks" => build_databricks_config(profile, cli_database, cli_schema),
+        other => Err(DbtoonError::Config {
+            message: format!("unknown backend type: '{}' (expected 'sqlserver' or 'databricks')", other),
+        }),
+    }
+}
 
-    // Resolve backend type: CLI > env > profile > error
-    let backend_str = args
-        .backend
-        .as_deref()
-        .or(profile.backend.as_deref())
+fn build_sqlserver_config(
+    profile: &TomlProfile,
+    cli_database: Option<&str>,
+) -> Result<BackendConfig, DbtoonError> {
+    let server = resolve_profile_string(profile.server.as_deref())?
         .ok_or_else(|| DbtoonError::Config {
-            message: "no backend specified — use --backend or configure a profile".to_string(),
+            message: "no 'server' specified for sqlserver backend".to_string(),
         })?;
 
-    let backend = match backend_str {
-        "sqlserver" => {
-            let server = args
-                .server
-                .as_deref()
-                .or(profile.server.as_deref())
-                .ok_or_else(|| DbtoonError::Config {
-                    message: "no server specified for sqlserver backend".to_string(),
-                })?
-                .to_string();
-
-            let database = args
-                .database
-                .as_deref()
-                .or(profile.database.as_deref())
-                .map(|s| s.to_string());
-
-            let windows_auth =
-                args.windows_auth || profile.windows_auth.unwrap_or(false);
-
-            let auth = if windows_auth {
-                SqlServerAuth::WindowsIntegrated
-            } else {
-                let username = args
-                    .username
-                    .as_deref()
-                    .or(profile.username.as_deref())
-                    .ok_or_else(|| DbtoonError::Config {
-                        message: "no username specified for SQL Server SQL Auth".to_string(),
-                    })?
-                    .to_string();
-
-                let password = resolve_secret(
-                    args.password.as_deref(),
-                    profile.password_env.as_deref(),
-                    "DBTOON_PASSWORD",
-                )
-                .or_else(|| {
-                    profile
-                        .password
-                        .as_ref()
-                        .map(|p| SecretString::from(p.clone()))
-                })
-                .ok_or_else(|| DbtoonError::Config {
-                    message: "no password specified for SQL Server SQL Auth".to_string(),
-                })?;
-
-                SqlServerAuth::SqlLogin { username, password }
-            };
-
-            let trust_server_certificate = args.trust_server_certificate
-                || profile.trust_server_certificate.unwrap_or(false);
-
-            BackendConfig::SqlServer {
-                server,
-                database,
-                auth,
-                trust_server_certificate,
-            }
-        }
-        "databricks" => {
-            let std_host = env_non_empty("DATABRICKS_HOST");
-            let std_warehouse = env_non_empty("DATABRICKS_SQL_WAREHOUSE_ID");
-            let std_catalog = env_non_empty("DATABRICKS_CATALOG");
-            let std_schema = env_non_empty("DATABRICKS_SCHEMA");
-
-            let host = non_empty(args.host.as_deref())
-                .or(non_empty(profile.host.as_deref()))
-                .or(std_host.as_deref())
-                .ok_or_else(|| DbtoonError::Config {
-                    message: "no host specified for databricks backend".to_string(),
-                })?
-                .to_string();
-
-            let token = resolve_secret(
-                args.token.as_deref(),
-                profile.token_env.as_deref(),
-                "DBTOON_DATABRICKS_TOKEN",
-            )
-            .or_else(|| {
-                profile
-                    .token
-                    .as_ref()
-                    .map(|t| SecretString::from(t.clone()))
-            })
-            .or_else(|| env_non_empty("DATABRICKS_TOKEN").map(SecretString::from))
-            .ok_or_else(|| DbtoonError::Config {
-                message: "no token specified for databricks backend".to_string(),
-            })?;
-
-            let warehouse_id = non_empty(args.warehouse.as_deref())
-                .or(non_empty(profile.warehouse_id.as_deref()))
-                .or(std_warehouse.as_deref())
-                .ok_or_else(|| DbtoonError::Config {
-                    message: "no warehouse ID specified for databricks backend".to_string(),
-                })?
-                .to_string();
-
-            let catalog = non_empty(args.catalog.as_deref())
-                .or(non_empty(profile.catalog.as_deref()))
-                .or(std_catalog.as_deref())
-                .map(|s| s.to_string());
-
-            let schema = non_empty(args.schema.as_deref())
-                .or(non_empty(profile.schema.as_deref()))
-                .or(std_schema.as_deref())
-                .map(|s| s.to_string());
-
-            BackendConfig::Databricks {
-                host,
-                token,
-                warehouse_id,
-                catalog,
-                schema,
-            }
-        }
-        other => {
-            return Err(DbtoonError::Config {
-                message: format!("unknown backend type: '{}' (expected 'sqlserver' or 'databricks')", other),
-            });
-        }
+    let database = if let Some(db) = cli_database {
+        Some(db.to_string())
+    } else {
+        resolve_profile_string(profile.database.as_deref())?
     };
 
-    // Resolve allow_write: env > config defaults
-    let allow_write = std::env::var("DBTOON_ALLOW_WRITE")
-        .map(|v| v == "true")
-        .unwrap_or(toml_config.defaults.allow_write.unwrap_or(false));
+    let windows_auth = profile.windows_auth.unwrap_or(false);
 
-    // row_limit: --no-limit > CLI/ENV > TOML > 500
+    let auth = if windows_auth {
+        SqlServerAuth::WindowsIntegrated
+    } else {
+        let username = resolve_profile_string(profile.username.as_deref())?
+            .ok_or_else(|| DbtoonError::Config {
+                message: "no 'username' specified for SQL Server SQL Auth".to_string(),
+            })?;
+
+        let password = resolve_profile_secret(profile.password.as_deref())?
+            .ok_or_else(|| DbtoonError::Config {
+                message: "no 'password' specified for SQL Server SQL Auth".to_string(),
+            })?;
+
+        SqlServerAuth::SqlLogin { username, password }
+    };
+
+    let trust_server_certificate = profile.trust_server_certificate.unwrap_or(false);
+
+    Ok(BackendConfig::SqlServer {
+        server,
+        database,
+        auth,
+        trust_server_certificate,
+    })
+}
+
+fn build_databricks_config(
+    profile: &TomlProfile,
+    cli_database: Option<&str>,
+    cli_schema: Option<&str>,
+) -> Result<BackendConfig, DbtoonError> {
+    // Databricks standard env vars as lowest-priority fallback
+    let std_host = env_non_empty("DATABRICKS_HOST");
+    let std_token = env_non_empty("DATABRICKS_TOKEN");
+    let std_warehouse = env_non_empty("DATABRICKS_SQL_WAREHOUSE_ID");
+    let std_catalog = env_non_empty("DATABRICKS_CATALOG");
+    let std_schema = env_non_empty("DATABRICKS_SCHEMA");
+
+    let host = resolve_profile_string(profile.host.as_deref())?
+        .or(std_host)
+        .ok_or_else(|| DbtoonError::Config {
+            message: "no 'host' specified for databricks backend".to_string(),
+        })?;
+
+    let token = resolve_profile_secret(profile.token.as_deref())?
+        .or_else(|| std_token.map(SecretString::from))
+        .ok_or_else(|| DbtoonError::Config {
+            message: "no 'token' specified for databricks backend".to_string(),
+        })?;
+
+    let warehouse_id = resolve_profile_string(profile.warehouse_id.as_deref())?
+        .or(std_warehouse)
+        .ok_or_else(|| DbtoonError::Config {
+            message: "no 'warehouse_id' specified for databricks backend".to_string(),
+        })?;
+
+    let catalog = if let Some(db) = cli_database {
+        Some(db.to_string())
+    } else {
+        resolve_profile_string(profile.catalog.as_deref())?
+            .or(std_catalog)
+    };
+
+    let schema = if let Some(s) = cli_schema {
+        Some(s.to_string())
+    } else {
+        resolve_profile_string(profile.schema.as_deref())?
+            .or(std_schema)
+    };
+
+    Ok(BackendConfig::Databricks {
+        host,
+        token,
+        warehouse_id,
+        catalog,
+        schema,
+    })
+}
+
+/// Build AppConfig from query args.
+pub fn load_from_query_args(
+    args: &QueryArgs,
+    toml_config: &TomlConfig,
+    verbose: bool,
+    show_secrets: bool,
+) -> Result<AppConfig, DbtoonError> {
+    let profile = load_profile(toml_config, &args.profile)?;
+
+    // --database and --catalog are aliases for a single concept
+    let cli_database = args.database.as_deref().or(args.catalog.as_deref());
+    let cli_schema = args.schema.as_deref();
+
+    let backend = build_backend_config(&profile, cli_database, cli_schema)?;
+
+    // allow_write: CLI flag > defaults > false
+    let allow_write = args.allow_write || toml_config.defaults.allow_write.unwrap_or(false);
+
+    // row_limit: --no-limit > --limit > defaults > 500
     let default_row_limit = if args.no_limit {
         None
     } else {
         Some(args.limit.unwrap_or_else(|| toml_config.defaults.row_limit.unwrap_or(500)))
     };
 
-    // timeout: CLI/ENV > TOML > 60
+    // timeout: --timeout > defaults > 60
     let query_timeout_secs = args.timeout
         .unwrap_or_else(|| toml_config.defaults.timeout.unwrap_or(60));
 
-    // verbose: CLI/ENV OR TOML default
+    // verbose: CLI flag OR defaults
     let verbose = verbose || toml_config.defaults.verbose.unwrap_or(false);
 
     Ok(AppConfig {
@@ -346,73 +362,15 @@ pub fn load_from_exec_args(
     })
 }
 
-/// Build AppConfig for list-warehouses subcommand.
-pub fn load_from_list_warehouses_args(
-    args: &ListWarehousesArgs,
+/// Build AppConfig for warehouse list.
+pub fn load_from_warehouse_list_args(
+    args: &WarehouseListArgs,
+    toml_config: &TomlConfig,
     verbose: bool,
     show_secrets: bool,
-    config_path: Option<&PathBuf>,
 ) -> Result<AppConfig, DbtoonError> {
-    let resolved_path = resolve_config_path(config_path);
-    let toml_config = load_toml_config(resolved_path.as_ref())?;
-
-    let profile = args.profile.as_ref().map(|name| {
-        toml_config.profiles.get(name).cloned().ok_or_else(|| DbtoonError::Config {
-            message: format!("profile '{}' not found in config file", name),
-        })
-    }).transpose()?;
-
-    let profile = profile.unwrap_or_default();
-
-    let std_host = env_non_empty("DATABRICKS_HOST");
-    let std_warehouse = env_non_empty("DATABRICKS_SQL_WAREHOUSE_ID");
-    let std_catalog = env_non_empty("DATABRICKS_CATALOG");
-    let std_schema = env_non_empty("DATABRICKS_SCHEMA");
-
-    let host = non_empty(args.host.as_deref())
-        .or(non_empty(profile.host.as_deref()))
-        .or(std_host.as_deref())
-        .ok_or_else(|| DbtoonError::Config {
-            message: "no host specified for list-warehouses".to_string(),
-        })?
-        .to_string();
-
-    let token = resolve_secret(
-        args.token.as_deref(),
-        profile.token_env.as_deref(),
-        "DBTOON_DATABRICKS_TOKEN",
-    )
-    .or_else(|| {
-        profile
-            .token
-            .as_ref()
-            .map(|t| SecretString::from(t.clone()))
-    })
-    .or_else(|| env_non_empty("DATABRICKS_TOKEN").map(SecretString::from))
-    .ok_or_else(|| DbtoonError::Config {
-        message: "no token specified for list-warehouses".to_string(),
-    })?;
-
-    let warehouse_id = non_empty(profile.warehouse_id.as_deref())
-        .or(std_warehouse.as_deref())
-        .unwrap_or_default()
-        .to_string();
-
-    let catalog = non_empty(profile.catalog.as_deref())
-        .or(std_catalog.as_deref())
-        .map(|s| s.to_string());
-
-    let schema = non_empty(profile.schema.as_deref())
-        .or(std_schema.as_deref())
-        .map(|s| s.to_string());
-
-    let backend = BackendConfig::Databricks {
-        host,
-        token,
-        warehouse_id,
-        catalog,
-        schema,
-    };
+    let profile = load_profile(toml_config, &args.profile)?;
+    let backend = build_backend_config(&profile, None, None)?;
 
     let verbose = verbose || toml_config.defaults.verbose.unwrap_or(false);
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,113 @@
+//! Config file initialization for `dbtoon init`.
+
+use crate::config::env_non_empty;
+use crate::error::DbtoonError;
+use std::path::Path;
+
+const DEFAULT_TEMPLATE: &str = r#"[defaults]
+row_limit = 500
+timeout = 60
+
+# Example profiles — uncomment and configure:
+#
+# [profiles.sqlserver_example]
+# backend = "sqlserver"
+# server = "localhost"
+# database = "mydb"
+# username = "sa"
+# password = "$SA_PASSWORD"
+#
+# [profiles.databricks_example]
+# backend = "databricks"
+# host = "$DATABRICKS_HOST"
+# token = "$DATABRICKS_TOKEN"
+# warehouse_id = "$DATABRICKS_SQL_WAREHOUSE_ID"
+# catalog = "$DATABRICKS_CATALOG"
+# schema = "$DATABRICKS_SCHEMA"
+"#;
+
+const DATABRICKS_ACTIVE_TEMPLATE: &str = r#"[defaults]
+row_limit = 500
+timeout = 60
+
+# Example SQL Server profile — uncomment and configure:
+#
+# [profiles.sqlserver_example]
+# backend = "sqlserver"
+# server = "localhost"
+# database = "mydb"
+# username = "sa"
+# password = "$SA_PASSWORD"
+
+[profiles.databricks]
+backend = "databricks"
+host = "$DATABRICKS_HOST"
+token = "$DATABRICKS_TOKEN"
+warehouse_id = "$DATABRICKS_SQL_WAREHOUSE_ID"
+catalog = "$DATABRICKS_CATALOG"
+schema = "$DATABRICKS_SCHEMA"
+"#;
+
+/// Run the `dbtoon init` command: create config file with defaults and example profiles.
+pub fn run_init(config_path: &Path) -> Result<(), DbtoonError> {
+    if config_path.exists() {
+        return Err(DbtoonError::Config {
+            message: format!(
+                "config file already exists: {}\n\nTo recreate, delete it first.",
+                config_path.display()
+            ),
+        });
+    }
+
+    // Create parent directory tree
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| DbtoonError::Config {
+            message: format!("cannot create config directory {}: {}", parent.display(), e),
+        })?;
+    }
+
+    // Detect Databricks env vars
+    let has_databricks = env_non_empty("DATABRICKS_HOST").is_some()
+        || env_non_empty("DATABRICKS_TOKEN").is_some();
+
+    let template = if has_databricks {
+        DATABRICKS_ACTIVE_TEMPLATE
+    } else {
+        DEFAULT_TEMPLATE
+    };
+
+    std::fs::write(config_path, template).map_err(|e| DbtoonError::Config {
+        message: format!("cannot write config file {}: {}", config_path.display(), e),
+    })?;
+
+    // Print guidance
+    eprintln!("Created config file: {}", config_path.display());
+
+    if has_databricks {
+        eprintln!("\nDetected Databricks environment variables.");
+        eprintln!("A 'databricks' profile has been created with $VAR references.");
+
+        // Check which required fields are still missing
+        let mut missing = Vec::new();
+        if env_non_empty("DATABRICKS_HOST").is_none() {
+            missing.push("DATABRICKS_HOST");
+        }
+        if env_non_empty("DATABRICKS_TOKEN").is_none() {
+            missing.push("DATABRICKS_TOKEN");
+        }
+        if env_non_empty("DATABRICKS_SQL_WAREHOUSE_ID").is_none() {
+            missing.push("DATABRICKS_SQL_WAREHOUSE_ID");
+        }
+        if !missing.is_empty() {
+            eprintln!("\nRequired env vars still missing: {}", missing.join(", "));
+        }
+
+        eprintln!("\nNext: dbtoon query -P databricks \"SELECT 1\"");
+    } else {
+        eprintln!("\nNext steps:");
+        eprintln!("  1. Create a profile: dbtoon profile create mydb --backend sqlserver");
+        eprintln!("  2. Or edit the config file directly: {}", config_path.display());
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ pub mod backend;
 pub mod cli;
 pub mod config;
 pub mod error;
+pub mod init;
+pub mod profile;
 pub mod format;
 pub mod format_arrow;
 pub mod format_columnar;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use dbtoon::cli::{self, Cli, Command};
+use dbtoon::cli::{self, Cli, Command, ProfileCommand};
 use dbtoon::error::DbtoonError;
 use dbtoon::verbose::{self, Timer};
 use dbtoon::format_detect::{self, OutputFormat};
@@ -14,14 +14,15 @@ async fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::ExecRead(ref args) => {
-            exec_read(args, cli.verbose, cli.show_secrets, cli.config.as_ref()).await
+        Command::Init => run_init(cli.config.as_ref()),
+        Command::Query(ref args) => {
+            run_query(args, cli.verbose, cli.show_secrets, cli.config.as_ref()).await
         }
-        Command::ExecWrite(ref args) => {
-            exec_write(args, cli.verbose, cli.show_secrets, cli.config.as_ref()).await
+        Command::Profile(ref cmd) => {
+            run_profile(cmd, cli.verbose, cli.show_secrets, cli.config.as_ref())
         }
-        Command::ListWarehouses(ref args) => {
-            list_warehouses(args, cli.verbose, cli.show_secrets, cli.config.as_ref()).await
+        Command::Warehouse(ref args) => {
+            run_warehouse(args, cli.verbose, cli.show_secrets, cli.config.as_ref()).await
         }
         Command::Update => dbtoon::update::run_update().map_err(|e| DbtoonError::Config {
             message: e.to_string(),
@@ -34,43 +35,58 @@ async fn main() {
     }
 }
 
-async fn exec_read(
-    args: &cli::ExecArgs,
+fn run_init(config_path: Option<&std::path::PathBuf>) -> Result<(), DbtoonError> {
+    let path = match config_path {
+        Some(p) => p.clone(),
+        None => config::default_config_path().ok_or_else(|| DbtoonError::Config {
+            message: "cannot determine config file location (HOME not set)".to_string(),
+        })?,
+    };
+    dbtoon::init::run_init(&path)
+}
+
+async fn run_query(
+    args: &cli::QueryArgs,
     verbose: bool,
     show_secrets: bool,
     config_path: Option<&std::path::PathBuf>,
 ) -> Result<(), DbtoonError> {
-    let app_config = config::load_from_exec_args(args, verbose, show_secrets, config_path)?;
+    let (toml_config, _config_file_path) = config::load_toml_config_required(config_path)?;
+    let app_config = config::load_from_query_args(args, &toml_config, verbose, show_secrets)?;
     let verbose = app_config.verbose;
 
     // Resolve SQL input
-    let sql = resolve_sql(args)?;
+    let sql = resolve_sql(&args.sql, &args.file)?;
 
-    // Validate query (read-only mode)
+    // Validation: block write queries unless --allow-write
     let dialect = match &app_config.backend {
         config::BackendConfig::SqlServer { .. } => validation::BackendDialect::SqlServer,
         config::BackendConfig::Databricks { .. } => validation::BackendDialect::Databricks,
     };
 
-    verbose::emit(verbose, "validating query (read-only mode)...");
-    let vtimer = Timer::start();
-    let validation_result = validation::validate(&sql, dialect);
-    match validation_result {
-        validation::ValidationResult::Safe => {
-            verbose::emit(
-                verbose,
-                &format!("validation passed ({}ms)", vtimer.elapsed_ms()),
-            );
+    if !app_config.allow_write {
+        verbose::emit(verbose, "validating query (read-only mode)...");
+        let vtimer = Timer::start();
+        let validation_result = validation::validate(&sql, dialect);
+        match validation_result {
+            validation::ValidationResult::Safe => {
+                verbose::emit(
+                    verbose,
+                    &format!("validation passed ({}ms)", vtimer.elapsed_ms()),
+                );
+            }
+            validation::ValidationResult::Denied { reasons } => {
+                verbose::emit(verbose, "validation failed");
+                let detail = reasons
+                    .iter()
+                    .map(|r| r.detail.clone())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                return Err(DbtoonError::Validation { reason: detail });
+            }
         }
-        validation::ValidationResult::Denied { reasons } => {
-            verbose::emit(verbose, "validation failed");
-            let detail = reasons
-                .iter()
-                .map(|r| r.detail.clone())
-                .collect::<Vec<_>>()
-                .join("; ");
-            return Err(DbtoonError::Validation { reason: detail });
-        }
+    } else {
+        verbose::emit(verbose, "write mode enabled — skipping validation");
     }
 
     // Detect output format before query (fail-fast on bad extension)
@@ -97,139 +113,126 @@ async fn exec_read(
     Ok(())
 }
 
-async fn exec_write(
-    args: &cli::ExecArgs,
-    verbose: bool,
+fn run_profile(
+    cmd: &ProfileCommand,
+    _verbose: bool,
     show_secrets: bool,
     config_path: Option<&std::path::PathBuf>,
 ) -> Result<(), DbtoonError> {
-    let app_config = config::load_from_exec_args(args, verbose, show_secrets, config_path)?;
-    let verbose = app_config.verbose;
+    let (_, config_file_path) = config::load_toml_config_required(config_path)?;
 
-    if !app_config.allow_write {
-        return Err(DbtoonError::Auth {
-            message: "write access denied — set DBTOON_ALLOW_WRITE=true to enable".to_string(),
-        });
+    match cmd {
+        ProfileCommand::Create(args) => {
+            dbtoon::profile::create_profile(&config_file_path, &args.name, &args.backend, &args.set_fields)
+        }
+        ProfileCommand::Edit(args) => {
+            dbtoon::profile::edit_profile(&config_file_path, &args.name, &args.set_fields, &args.unset_fields)
+        }
+        ProfileCommand::Show(args) => {
+            let output = dbtoon::profile::show_profile(&config_file_path, &args.name, show_secrets)?;
+            print!("{}", output);
+            Ok(())
+        }
+        ProfileCommand::List => {
+            let names = dbtoon::profile::list_profiles(&config_file_path)?;
+            for name in &names {
+                println!("{}", name);
+            }
+            Ok(())
+        }
+        ProfileCommand::Test(args) => {
+            dbtoon::profile::test_profile(&config_file_path, &args.name)
+        }
+        ProfileCommand::Delete(args) => {
+            dbtoon::profile::delete_profile(&config_file_path, &args.name)
+        }
+        ProfileCommand::Rename(args) => {
+            dbtoon::profile::rename_profile(&config_file_path, &args.old, &args.new)
+        }
     }
-
-    let sql = resolve_sql(args)?;
-
-    // Detect output format before query (fail-fast on bad extension)
-    let format_info = if let Some(ref path) = app_config.output_file {
-        Some(format_detect::detect_format(path)?)
-    } else {
-        None
-    };
-
-    verbose::emit(verbose, "executing write query (validation skipped)...");
-
-    // Skip validation — execute directly
-    let result = execute_query(&app_config, &sql, verbose).await?;
-
-    let format_label = match &format_info {
-        Some((OutputFormat::Toon, _)) => "TOON",
-        Some((OutputFormat::Csv, _)) => "CSV",
-        Some((OutputFormat::Parquet, _)) => "Parquet",
-        Some((OutputFormat::Arrow, _)) => "Arrow IPC",
-        None => "TOON",
-    };
-    verbose::emit(verbose, &format!("formatting {format_label} output..."));
-    output_result(&app_config, &result, format_info)?;
-
-    Ok(())
 }
 
-async fn list_warehouses(
-    args: &cli::ListWarehousesArgs,
+async fn run_warehouse(
+    args: &cli::WarehouseArgs,
     verbose: bool,
     show_secrets: bool,
     config_path: Option<&std::path::PathBuf>,
 ) -> Result<(), DbtoonError> {
-    let app_config =
-        config::load_from_list_warehouses_args(args, verbose, show_secrets, config_path)?;
-    let verbose = app_config.verbose;
+    match &args.command {
+        cli::WarehouseCommand::List(list_args) => {
+            let (toml_config, _) = config::load_toml_config_required(config_path)?;
+            let app_config = config::load_from_warehouse_list_args(
+                list_args, &toml_config, verbose, show_secrets,
+            )?;
+            let verbose = app_config.verbose;
 
-    let (host, token) = match &app_config.backend {
-        config::BackendConfig::Databricks { host, token, .. } => (host.clone(), token.clone()),
-        _ => {
-            return Err(DbtoonError::Config {
-                message: "list-warehouses requires a databricks backend".to_string(),
-            });
+            let (host, token) = match &app_config.backend {
+                config::BackendConfig::Databricks { host, token, .. } => (host.clone(), token.clone()),
+                _ => {
+                    return Err(DbtoonError::Config {
+                        message: "warehouse list requires a databricks profile".to_string(),
+                    });
+                }
+            };
+
+            verbose::emit(verbose, &format!("listing warehouses on {}...", host));
+            let timer = Timer::start();
+            let warehouses = backend::databricks::list_warehouses(&host, &token).await?;
+            verbose::emit(
+                verbose,
+                &format!(
+                    "warehouse list retrieved ({}ms, {} warehouses)",
+                    timer.elapsed_ms(),
+                    warehouses.len()
+                ),
+            );
+
+            let columns = vec![
+                backend::ColumnMeta { name: "id".to_string(), type_name: "STRING".to_string() },
+                backend::ColumnMeta { name: "name".to_string(), type_name: "STRING".to_string() },
+                backend::ColumnMeta { name: "state".to_string(), type_name: "STRING".to_string() },
+                backend::ColumnMeta { name: "cluster_size".to_string(), type_name: "STRING".to_string() },
+                backend::ColumnMeta { name: "type".to_string(), type_name: "STRING".to_string() },
+            ];
+
+            let rows = warehouses
+                .into_iter()
+                .map(|w| {
+                    vec![
+                        backend::CellValue::Text(w.id),
+                        backend::CellValue::Text(w.name),
+                        backend::CellValue::Text(w.state),
+                        backend::CellValue::Text(w.cluster_size),
+                        match w.warehouse_type {
+                            Some(t) => backend::CellValue::Text(t),
+                            None => backend::CellValue::Null,
+                        },
+                    ]
+                })
+                .collect();
+
+            let query_result = backend::QueryResult {
+                columns,
+                rows,
+                total_rows: None,
+                truncated: false,
+            };
+
+            let toon = format::to_toon(&query_result, false, None)?;
+            output::print_result(&toon);
+
+            Ok(())
         }
-    };
-
-    verbose::emit(verbose, &format!("listing warehouses on {}...", host));
-    let timer = Timer::start();
-    let warehouses = backend::databricks::list_warehouses(&host, &token).await?;
-    verbose::emit(
-        verbose,
-        &format!(
-            "warehouse list retrieved ({}ms, {} warehouses)",
-            timer.elapsed_ms(),
-            warehouses.len()
-        ),
-    );
-
-    // Convert to QueryResult for TOON output
-    let columns = vec![
-        backend::ColumnMeta {
-            name: "id".to_string(),
-            type_name: "STRING".to_string(),
-        },
-        backend::ColumnMeta {
-            name: "name".to_string(),
-            type_name: "STRING".to_string(),
-        },
-        backend::ColumnMeta {
-            name: "state".to_string(),
-            type_name: "STRING".to_string(),
-        },
-        backend::ColumnMeta {
-            name: "cluster_size".to_string(),
-            type_name: "STRING".to_string(),
-        },
-        backend::ColumnMeta {
-            name: "type".to_string(),
-            type_name: "STRING".to_string(),
-        },
-    ];
-
-    let rows = warehouses
-        .into_iter()
-        .map(|w| {
-            vec![
-                backend::CellValue::Text(w.id),
-                backend::CellValue::Text(w.name),
-                backend::CellValue::Text(w.state),
-                backend::CellValue::Text(w.cluster_size),
-                match w.warehouse_type {
-                    Some(t) => backend::CellValue::Text(t),
-                    None => backend::CellValue::Null,
-                },
-            ]
-        })
-        .collect();
-
-    let query_result = backend::QueryResult {
-        columns,
-        rows,
-        total_rows: None,
-        truncated: false,
-    };
-
-    let toon = format::to_toon(&query_result, false, None)?;
-    output::print_result(&toon);
-
-    Ok(())
+    }
 }
 
 // --- Helpers ---
 
-fn resolve_sql(args: &cli::ExecArgs) -> Result<String, DbtoonError> {
-    if let Some(ref sql) = args.sql {
+fn resolve_sql(sql: &Option<String>, file: &Option<std::path::PathBuf>) -> Result<String, DbtoonError> {
+    if let Some(sql) = sql {
         return Ok(sql.clone());
     }
-    if let Some(ref path) = args.sql_file {
+    if let Some(path) = file {
         let content = std::fs::read_to_string(path).map_err(|e| DbtoonError::Config {
             message: format!("cannot read SQL file {}: {}", path.display(), e),
         })?;
@@ -332,7 +335,6 @@ fn output_result(
     result: &backend::QueryResult,
     format_info: Option<(OutputFormat, std::path::PathBuf)>,
 ) -> Result<(), DbtoonError> {
-    // Build truncation message once
     let message = if result.truncated {
         Some(format!(
             "Showing {} rows. Use --no-limit to return all rows.",
@@ -374,7 +376,6 @@ fn output_result(
         output::print_result(&toon);
     }
 
-    // Stderr warning (all formats, when truncated)
     if let Some(ref msg) = message {
         output::print_truncation_warning(msg);
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,423 @@
+//! Profile management for `dbtoon profile` subcommands.
+
+use crate::config::resolve_env_var;
+use crate::error::DbtoonError;
+use std::path::Path;
+use toml_edit::{DocumentMut, Item, Table, value};
+
+/// Valid fields per backend (excluding `backend` which is always set at creation).
+const SQLSERVER_FIELDS: &[&str] = &[
+    "server", "database", "username", "password",
+    "windows_auth", "trust_server_certificate",
+];
+
+const DATABRICKS_FIELDS: &[&str] = &[
+    "host", "token", "warehouse_id", "catalog", "schema",
+];
+
+/// Secret fields that should be masked in `profile show`.
+const SECRET_FIELDS: &[&str] = &["password", "token"];
+
+fn valid_fields(backend: &str) -> Result<&'static [&'static str], DbtoonError> {
+    match backend {
+        "sqlserver" => Ok(SQLSERVER_FIELDS),
+        "databricks" => Ok(DATABRICKS_FIELDS),
+        other => Err(DbtoonError::Config {
+            message: format!("unknown backend type: '{}' (expected 'sqlserver' or 'databricks')", other),
+        }),
+    }
+}
+
+fn validate_field(backend: &str, field: &str) -> Result<(), DbtoonError> {
+    let fields = valid_fields(backend)?;
+    if !fields.contains(&field) && field != "backend" {
+        return Err(DbtoonError::Config {
+            message: format!(
+                "invalid field '{}' for {} backend (valid: {})",
+                field, backend, fields.join(", ")
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn read_doc(path: &Path) -> Result<DocumentMut, DbtoonError> {
+    let content = std::fs::read_to_string(path).map_err(|e| DbtoonError::Config {
+        message: format!("cannot read config file {}: {}", path.display(), e),
+    })?;
+    content.parse::<DocumentMut>().map_err(|e| DbtoonError::Config {
+        message: format!("invalid TOML in {}: {}", path.display(), e),
+    })
+}
+
+fn write_doc(path: &Path, doc: &DocumentMut) -> Result<(), DbtoonError> {
+    std::fs::write(path, doc.to_string()).map_err(|e| DbtoonError::Config {
+        message: format!("cannot write config file {}: {}", path.display(), e),
+    })
+}
+
+/// Ensure the `[profiles]` table exists in the document.
+fn ensure_profiles_table(doc: &mut DocumentMut) {
+    if !doc.contains_key("profiles") {
+        doc["profiles"] = Item::Table(Table::new());
+    }
+}
+
+fn parse_set_field(kv: &str) -> Result<(&str, &str), DbtoonError> {
+    let Some((key, val)) = kv.split_once('=') else {
+        return Err(DbtoonError::Config {
+            message: format!("invalid --set syntax: '{}' (expected key=value)", kv),
+        });
+    };
+    Ok((key.trim(), val.trim()))
+}
+
+/// Create a new profile in the config file.
+pub fn create_profile(
+    config_path: &Path,
+    name: &str,
+    backend: &str,
+    set_fields: &[String],
+) -> Result<(), DbtoonError> {
+    // Validate backend
+    let valid = valid_fields(backend)?;
+
+    // Validate --set fields
+    for kv in set_fields {
+        let (key, _) = parse_set_field(kv)?;
+        validate_field(backend, key)?;
+    }
+
+    let mut doc = read_doc(config_path)?;
+    ensure_profiles_table(&mut doc);
+
+    // Check for duplicate
+    if let Some(profiles) = doc["profiles"].as_table()
+        && profiles.contains_key(name) {
+            return Err(DbtoonError::Config {
+                message: format!("profile '{}' already exists", name),
+            });
+        }
+
+    // Build profile table with defaults
+    let mut profile = Table::new();
+    profile["backend"] = value(backend);
+
+    match backend {
+        "databricks" => {
+            profile["host"] = value("$DATABRICKS_HOST");
+            profile["token"] = value("$DATABRICKS_TOKEN");
+            profile["warehouse_id"] = value("$DATABRICKS_SQL_WAREHOUSE_ID");
+            profile["catalog"] = value("$DATABRICKS_CATALOG");
+            profile["schema"] = value("$DATABRICKS_SCHEMA");
+        }
+        "sqlserver" => {
+            profile["server"] = value("localhost");
+            profile["database"] = value("mydb");
+            profile["username"] = value("sa");
+            profile["password"] = value("$SA_PASSWORD");
+        }
+        _ => {} // Already validated above
+    }
+
+    // Apply --set overrides
+    for kv in set_fields {
+        let (key, val) = parse_set_field(kv)?;
+        if val.is_empty() {
+            profile.remove(key);
+        } else {
+            // Bool fields
+            if key == "windows_auth" || key == "trust_server_certificate" {
+                match val {
+                    "true" => { profile[key] = value(true); }
+                    "false" => { profile[key] = value(false); }
+                    _ => {
+                        return Err(DbtoonError::Config {
+                            message: format!("field '{}' must be 'true' or 'false', got '{}'", key, val),
+                        });
+                    }
+                }
+            } else {
+                profile[key] = value(val);
+            }
+        }
+    }
+
+    doc["profiles"][name] = Item::Table(profile);
+    write_doc(config_path, &doc)?;
+
+    eprintln!("Created profile '{}'", name);
+    let _ = valid; // suppress unused warning
+    Ok(())
+}
+
+/// Edit an existing profile.
+pub fn edit_profile(
+    config_path: &Path,
+    name: &str,
+    set_fields: &[String],
+    unset_fields: &[String],
+) -> Result<(), DbtoonError> {
+    let mut doc = read_doc(config_path)?;
+
+    // Get the profile and its backend
+    let backend = {
+        let profiles = doc.get("profiles")
+            .and_then(|p| p.as_table())
+            .ok_or_else(|| DbtoonError::Config {
+                message: format!("profile '{}' not found in config file", name),
+            })?;
+        let profile = profiles.get(name).ok_or_else(|| DbtoonError::Config {
+            message: format!("profile '{}' not found in config file", name),
+        })?;
+        profile.get("backend")
+            .and_then(|b| b.as_str())
+            .unwrap_or("unknown")
+            .to_string()
+    };
+
+    // Validate fields
+    for kv in set_fields {
+        let (key, _) = parse_set_field(kv)?;
+        if key != "backend" {
+            validate_field(&backend, key)?;
+        }
+    }
+    for key in unset_fields {
+        if key != "backend" {
+            validate_field(&backend, key)?;
+        }
+    }
+
+    // Apply changes
+    for kv in set_fields {
+        let (key, val) = parse_set_field(kv)?;
+        if val.is_empty() {
+            // Remove field
+            if let Some(profile) = doc["profiles"][name].as_table_mut() {
+                profile.remove(key);
+            }
+        } else {
+            // Bool fields
+            if key == "windows_auth" || key == "trust_server_certificate" {
+                match val {
+                    "true" => { doc["profiles"][name][key] = value(true); }
+                    "false" => { doc["profiles"][name][key] = value(false); }
+                    _ => {
+                        return Err(DbtoonError::Config {
+                            message: format!("field '{}' must be 'true' or 'false', got '{}'", key, val),
+                        });
+                    }
+                }
+            } else {
+                doc["profiles"][name][key] = value(val);
+            }
+        }
+    }
+
+    for key in unset_fields {
+        if let Some(profile) = doc["profiles"][name].as_table_mut() {
+            profile.remove(key.as_str());
+        }
+    }
+
+    write_doc(config_path, &doc)?;
+    eprintln!("Updated profile '{}'", name);
+    Ok(())
+}
+
+/// Show a profile with resolved values and masking.
+pub fn show_profile(
+    config_path: &Path,
+    name: &str,
+    show_secrets: bool,
+) -> Result<String, DbtoonError> {
+    let doc = read_doc(config_path)?;
+
+    let profiles = doc["profiles"].as_table().ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' not found in config file", name),
+    })?;
+    let profile = profiles.get(name).ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' not found in config file", name),
+    })?;
+    let profile_table = profile.as_table().ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' is not a valid table", name),
+    })?;
+
+    let mut output = format!("[profiles.{}]\n", name);
+
+    for (key, item) in profile_table.iter() {
+        let raw_value = item.as_str().unwrap_or_default();
+        let is_secret = SECRET_FIELDS.contains(&key);
+
+        if let Some(var_name) = raw_value.strip_prefix('$')
+            && !var_name.starts_with('$') {
+                // It's a $VAR reference
+                match resolve_env_var(raw_value) {
+                    Ok(resolved) => {
+                        let display = if is_secret && !show_secrets {
+                            "****".to_string()
+                        } else {
+                            resolved
+                        };
+                        output.push_str(&format!(
+                            "{} = \"{}\" (${} = \"{}\")\n",
+                            key, raw_value, var_name, display
+                        ));
+                    }
+                    Err(_) => {
+                        output.push_str(&format!(
+                            "{} = \"{}\" (WARNING: ${} is not set)\n",
+                            key, raw_value, var_name
+                        ));
+                    }
+                }
+                continue;
+            }
+
+        // Literal value or bool
+        if is_secret && !show_secrets {
+            if item.as_str().is_some() {
+                output.push_str(&format!("{} = \"****\"\n", key));
+            } else {
+                output.push_str(&format!("{} = {}\n", key, item));
+            }
+        } else {
+            output.push_str(&format!("{} = {}\n", key, item));
+        }
+    }
+
+    Ok(output)
+}
+
+/// List all profile names.
+pub fn list_profiles(config_path: &Path) -> Result<Vec<String>, DbtoonError> {
+    let doc = read_doc(config_path)?;
+
+    let names = match doc["profiles"].as_table() {
+        Some(profiles) => profiles.iter().map(|(k, _)| k.to_string()).collect(),
+        None => Vec::new(),
+    };
+
+    Ok(names)
+}
+
+/// Delete a profile.
+pub fn delete_profile(config_path: &Path, name: &str) -> Result<(), DbtoonError> {
+    let mut doc = read_doc(config_path)?;
+
+    let profiles = doc["profiles"].as_table_mut().ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' not found in config file", name),
+    })?;
+
+    if profiles.remove(name).is_none() {
+        return Err(DbtoonError::Config {
+            message: format!("profile '{}' not found in config file", name),
+        });
+    }
+
+    write_doc(config_path, &doc)?;
+    eprintln!("Deleted profile '{}'", name);
+    Ok(())
+}
+
+/// Test a profile by validating required fields and attempting connection.
+///
+/// This validates that all required fields for the backend are present and resolvable.
+/// Actual connectivity testing requires a backend connection, which is only attempted
+/// if field validation passes.
+pub fn test_profile(config_path: &Path, name: &str) -> Result<(), DbtoonError> {
+    let doc = read_doc(config_path)?;
+
+    let profiles = doc.get("profiles")
+        .and_then(|p| p.as_table())
+        .ok_or_else(|| DbtoonError::Config {
+            message: format!("profile '{}' not found in config file", name),
+        })?;
+    let profile = profiles.get(name).ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' not found in config file", name),
+    })?;
+    let profile_table = profile.as_table().ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' is not a valid table", name),
+    })?;
+
+    let backend = profile_table.get("backend")
+        .and_then(|b| b.as_str())
+        .ok_or_else(|| DbtoonError::Config {
+            message: format!("profile '{}' has no 'backend' field", name),
+        })?;
+
+    // Check required fields
+    let required: &[&str] = match backend {
+        "sqlserver" => &["server"],
+        "databricks" => &["host", "token", "warehouse_id"],
+        other => return Err(DbtoonError::Config {
+            message: format!("unknown backend type: '{}'", other),
+        }),
+    };
+
+    let mut missing = Vec::new();
+    for field in required {
+        match profile_table.get(field) {
+            Some(item) if item.as_str().is_some() => {
+                // Try to resolve $VAR references
+                let val = item.as_str().unwrap();
+                if let Err(e) = resolve_env_var(val) {
+                    return Err(DbtoonError::Config {
+                        message: format!("profile '{}' field '{}': {}", name, field, e),
+                    });
+                }
+            }
+            _ => missing.push(*field),
+        }
+    }
+
+    if !missing.is_empty() {
+        return Err(DbtoonError::Config {
+            message: format!(
+                "profile '{}' is missing required fields: {}",
+                name, missing.join(", ")
+            ),
+        });
+    }
+
+    // If we got here, all required fields are present and resolvable.
+    // Actual connectivity testing would require backend connection here.
+    eprintln!("Profile '{}' configuration is valid ({} backend)", name, backend);
+    eprintln!("Note: connectivity testing requires a live connection (not yet implemented)");
+    Ok(())
+}
+
+/// Rename a profile.
+pub fn rename_profile(
+    config_path: &Path,
+    old_name: &str,
+    new_name: &str,
+) -> Result<(), DbtoonError> {
+    let mut doc = read_doc(config_path)?;
+
+    let profiles = doc["profiles"].as_table_mut().ok_or_else(|| DbtoonError::Config {
+        message: format!("profile '{}' not found in config file", old_name),
+    })?;
+
+    if !profiles.contains_key(old_name) {
+        return Err(DbtoonError::Config {
+            message: format!("profile '{}' not found in config file", old_name),
+        });
+    }
+
+    if profiles.contains_key(new_name) {
+        return Err(DbtoonError::Config {
+            message: format!("profile '{}' already exists", new_name),
+        });
+    }
+
+    // Get the old profile's item, clone it, insert with new name, remove old
+    let old_item = profiles.get(old_name).unwrap().clone();
+    profiles.insert(new_name, old_item);
+    profiles.remove(old_name);
+
+    write_doc(config_path, &doc)?;
+    eprintln!("Renamed profile '{}' to '{}'", old_name, new_name);
+    Ok(())
+}

--- a/tests/unit/cli_test.rs
+++ b/tests/unit/cli_test.rs
@@ -1,0 +1,371 @@
+use clap::Parser;
+use dbtoon::cli::Cli;
+
+/// Parse a CLI command from args (simulating shell invocation).
+fn parse_cli(args: &[&str]) -> Result<Cli, clap::Error> {
+    Cli::try_parse_from(args)
+}
+
+// =====================================================================
+// T006: CLI parsing tests for new command structure
+// =====================================================================
+
+// --- Init ---
+
+#[test]
+fn test_cli_init_command() {
+    let cli = parse_cli(&["dbtoon", "init"]).unwrap();
+    assert!(matches!(cli.command, dbtoon::cli::Command::Init));
+}
+
+// --- Query ---
+
+#[test]
+fn test_cli_query_requires_profile() {
+    let result = parse_cli(&["dbtoon", "query", "SELECT 1"]);
+    assert!(result.is_err(), "query without -P should fail");
+}
+
+#[test]
+fn test_cli_query_with_profile_and_sql() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert_eq!(args.profile, "dev");
+            assert_eq!(args.sql.as_deref(), Some("SELECT 1"));
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_file() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "-f", "query.sql"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert_eq!(args.profile, "dev");
+            assert!(args.file.is_some());
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_sql_conflicts_with_file() {
+    let result = parse_cli(&["dbtoon", "query", "-P", "dev", "SELECT 1", "-f", "query.sql"]);
+    assert!(result.is_err(), "SQL and --file should conflict");
+}
+
+#[test]
+fn test_cli_query_database_and_catalog_conflict() {
+    let result = parse_cli(&[
+        "dbtoon", "query", "-P", "dev", "-d", "mydb", "--catalog", "mycat", "SELECT 1",
+    ]);
+    assert!(result.is_err(), "--database and --catalog should conflict");
+}
+
+#[test]
+fn test_cli_query_with_database_short() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "-d", "mydb", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert_eq!(args.database.as_deref(), Some("mydb"));
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_catalog() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "--catalog", "mycat", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert_eq!(args.catalog.as_deref(), Some("mycat"));
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_schema() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "-s", "myschema", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert_eq!(args.schema.as_deref(), Some("myschema"));
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_limit() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "-l", "100", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert_eq!(args.limit, Some(100));
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_no_limit() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "--no-limit", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert!(args.no_limit);
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_timeout() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "-t", "120", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert_eq!(args.timeout, Some(120));
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_output() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "-o", "out.csv", "SELECT 1"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert!(args.output.is_some());
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+#[test]
+fn test_cli_query_with_allow_write() {
+    let cli = parse_cli(&["dbtoon", "query", "-P", "dev", "--allow-write", "INSERT INTO t VALUES(1)"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Query(args) => {
+            assert!(args.allow_write);
+        }
+        _ => panic!("Expected Query command"),
+    }
+}
+
+// --- Profile ---
+
+#[test]
+fn test_cli_profile_create() {
+    let cli = parse_cli(&["dbtoon", "profile", "create", "mydb", "--backend", "sqlserver"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Create(args)) => {
+            assert_eq!(args.name, "mydb");
+            assert_eq!(args.backend, "sqlserver");
+        }
+        _ => panic!("Expected Profile Create command"),
+    }
+}
+
+#[test]
+fn test_cli_profile_create_with_set() {
+    let cli = parse_cli(&[
+        "dbtoon", "profile", "create", "mydb", "--backend", "sqlserver",
+        "--set", "server=localhost", "--set", "database=testdb",
+    ]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Create(args)) => {
+            assert_eq!(args.set_fields.len(), 2);
+            assert_eq!(args.set_fields[0], "server=localhost");
+        }
+        _ => panic!("Expected Profile Create command"),
+    }
+}
+
+#[test]
+fn test_cli_profile_edit() {
+    let cli = parse_cli(&["dbtoon", "profile", "edit", "mydb", "--set", "database=newdb"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Edit(args)) => {
+            assert_eq!(args.name, "mydb");
+            assert_eq!(args.set_fields[0], "database=newdb");
+        }
+        _ => panic!("Expected Profile Edit command"),
+    }
+}
+
+#[test]
+fn test_cli_profile_edit_unset() {
+    let cli = parse_cli(&["dbtoon", "profile", "edit", "mydb", "--unset", "database"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Edit(args)) => {
+            assert_eq!(args.unset_fields[0], "database");
+        }
+        _ => panic!("Expected Profile Edit command"),
+    }
+}
+
+#[test]
+fn test_cli_profile_show() {
+    let cli = parse_cli(&["dbtoon", "profile", "show", "mydb"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Show(args)) => {
+            assert_eq!(args.name, "mydb");
+        }
+        _ => panic!("Expected Profile Show command"),
+    }
+}
+
+#[test]
+fn test_cli_profile_list() {
+    let cli = parse_cli(&["dbtoon", "profile", "list"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::List)
+    ));
+}
+
+#[test]
+fn test_cli_profile_test() {
+    let cli = parse_cli(&["dbtoon", "profile", "test", "mydb"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Test(args)) => {
+            assert_eq!(args.name, "mydb");
+        }
+        _ => panic!("Expected Profile Test command"),
+    }
+}
+
+#[test]
+fn test_cli_profile_delete() {
+    let cli = parse_cli(&["dbtoon", "profile", "delete", "mydb"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Delete(args)) => {
+            assert_eq!(args.name, "mydb");
+        }
+        _ => panic!("Expected Profile Delete command"),
+    }
+}
+
+#[test]
+fn test_cli_profile_rename() {
+    let cli = parse_cli(&["dbtoon", "profile", "rename", "old", "new"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Profile(dbtoon::cli::ProfileCommand::Rename(args)) => {
+            assert_eq!(args.old, "old");
+            assert_eq!(args.new, "new");
+        }
+        _ => panic!("Expected Profile Rename command"),
+    }
+}
+
+// --- Warehouse ---
+
+#[test]
+fn test_cli_warehouse_list_requires_profile() {
+    let result = parse_cli(&["dbtoon", "warehouse", "list"]);
+    assert!(result.is_err(), "warehouse list without -P should fail");
+}
+
+#[test]
+fn test_cli_warehouse_list_with_profile() {
+    let cli = parse_cli(&["dbtoon", "warehouse", "list", "-P", "dbx"]).unwrap();
+    match &cli.command {
+        dbtoon::cli::Command::Warehouse(args) => {
+            match &args.command {
+                dbtoon::cli::WarehouseCommand::List(list_args) => {
+                    assert_eq!(list_args.profile, "dbx");
+                }
+            }
+        }
+        _ => panic!("Expected Warehouse command"),
+    }
+}
+
+// --- Global flags ---
+
+#[test]
+fn test_cli_global_config_flag() {
+    let cli = parse_cli(&["dbtoon", "-c", "/custom/config.toml", "init"]).unwrap();
+    assert_eq!(
+        cli.config,
+        Some(std::path::PathBuf::from("/custom/config.toml"))
+    );
+}
+
+#[test]
+fn test_cli_global_verbose_flag() {
+    let cli = parse_cli(&["dbtoon", "-v", "init"]).unwrap();
+    assert!(cli.verbose);
+}
+
+#[test]
+fn test_cli_global_show_secrets_flag() {
+    let cli = parse_cli(&["dbtoon", "--show-secrets", "init"]).unwrap();
+    assert!(cli.show_secrets);
+}
+
+// =====================================================================
+// T042: Legacy commands and flags are rejected
+// =====================================================================
+
+#[test]
+fn test_exec_read_rejected() {
+    let result = parse_cli(&["dbtoon", "exec-read", "SELECT 1"]);
+    assert!(result.is_err(), "exec-read should be unrecognized");
+}
+
+#[test]
+fn test_exec_write_rejected() {
+    let result = parse_cli(&["dbtoon", "exec-write", "SELECT 1"]);
+    assert!(result.is_err(), "exec-write should be unrecognized");
+}
+
+#[test]
+fn test_list_warehouses_rejected() {
+    let result = parse_cli(&["dbtoon", "list-warehouses"]);
+    assert!(result.is_err(), "list-warehouses should be unrecognized");
+}
+
+#[test]
+fn test_query_server_flag_rejected() {
+    let result = parse_cli(&["dbtoon", "query", "-P", "dev", "--server", "localhost", "SELECT 1"]);
+    assert!(result.is_err(), "--server should be unrecognized on query");
+}
+
+#[test]
+fn test_query_host_flag_rejected() {
+    let result = parse_cli(&["dbtoon", "query", "-P", "dev", "--host", "ws.databricks.net", "SELECT 1"]);
+    assert!(result.is_err(), "--host should be unrecognized on query");
+}
+
+#[test]
+fn test_query_token_flag_rejected() {
+    let result = parse_cli(&["dbtoon", "query", "-P", "dev", "--token", "dapi-123", "SELECT 1"]);
+    assert!(result.is_err(), "--token should be unrecognized on query");
+}
+
+#[test]
+fn test_query_backend_flag_rejected() {
+    let result = parse_cli(&["dbtoon", "query", "-P", "dev", "--backend", "sqlserver", "SELECT 1"]);
+    assert!(result.is_err(), "--backend should be unrecognized on query");
+}
+
+#[test]
+fn test_warehouse_list_host_flag_rejected() {
+    let result = parse_cli(&["dbtoon", "warehouse", "list", "-P", "dbx", "--host", "ws.databricks.net"]);
+    assert!(result.is_err(), "--host should be unrecognized on warehouse list");
+}
+
+#[test]
+fn test_warehouse_list_token_flag_rejected() {
+    let result = parse_cli(&["dbtoon", "warehouse", "list", "-P", "dbx", "--token", "dapi-123"]);
+    assert!(result.is_err(), "--token should be unrecognized on warehouse list");
+}
+
+// --- Update ---
+
+#[test]
+fn test_cli_update_command() {
+    let cli = parse_cli(&["dbtoon", "update"]).unwrap();
+    assert!(matches!(cli.command, dbtoon::cli::Command::Update));
+}

--- a/tests/unit/config_test.rs
+++ b/tests/unit/config_test.rs
@@ -1,13 +1,13 @@
-use dbtoon::cli::{ExecArgs, ListWarehousesArgs};
 use dbtoon::config::{
-    env_non_empty, load_from_exec_args, load_from_list_warehouses_args, non_empty, BackendConfig,
-    SqlServerAuth,
+    self, default_config_path, env_non_empty, load_toml_config_required,
+    non_empty, resolve_env_var, resolve_profile_string, resolve_profile_secret,
+    BackendConfig, SqlServerAuth, TomlConfig, TomlProfile,
 };
 use secrecy::ExposeSecret;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-// --- Env var test infrastructure (T001) ---
+// --- Env var test infrastructure ---
 
 /// Static mutex to serialize tests that touch process env vars.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -24,7 +24,6 @@ impl EnvGuard {
     fn new(vars: &[(&str, &str)]) -> Self {
         let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         for (key, val) in vars {
-            // SAFETY: env var access is serialized by ENV_MUTEX
             unsafe { std::env::set_var(key, val); }
         }
         EnvGuard {
@@ -37,190 +36,24 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         for key in &self.keys {
-            // SAFETY: env var access is serialized by ENV_MUTEX
             unsafe { std::env::remove_var(key); }
         }
     }
 }
 
-fn make_exec_args(overrides: impl FnOnce(&mut ExecArgs)) -> ExecArgs {
-    let mut args = ExecArgs {
-        sql: Some("SELECT 1".to_string()),
-        sql_file: None,
-        backend: None,
-        server: None,
-        database: None,
-        username: None,
-        password: None,
-        windows_auth: false,
-        trust_server_certificate: false,
-        host: None,
-        token: None,
-        warehouse: None,
-        catalog: None,
-        schema: None,
-        limit: None,
-        no_limit: false,
-        timeout: None,
-        output: None,
-        profile: None,
-    };
-    overrides(&mut args);
-    args
-}
-
-#[test]
-fn test_sqlserver_windows_auth_config() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.database = Some("testdb".to_string());
-        a.windows_auth = true;
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::SqlServer { server, database, auth, .. } => {
-            assert_eq!(server, "localhost");
-            assert_eq!(database.as_deref(), Some("testdb"));
-            assert!(matches!(auth, SqlServerAuth::WindowsIntegrated));
-        }
-        _ => panic!("Expected SqlServer backend"),
+/// Helper to build a TomlConfig with a single profile for testing.
+fn make_toml_config(profile_name: &str, profile: TomlProfile) -> TomlConfig {
+    let mut profiles = std::collections::HashMap::new();
+    profiles.insert(profile_name.to_string(), profile);
+    TomlConfig {
+        defaults: Default::default(),
+        profiles,
     }
 }
 
-#[test]
-fn test_sqlserver_sql_auth_config() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.username = Some("sa".to_string());
-        a.password = Some("secret".to_string());
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::SqlServer { auth, .. } => {
-            assert!(matches!(auth, SqlServerAuth::SqlLogin { .. }));
-        }
-        _ => panic!("Expected SqlServer backend"),
-    }
-}
-
-#[test]
-fn test_missing_backend_errors() {
-    let args = make_exec_args(|_| {});
-    let result = load_from_exec_args(&args, false, false, None);
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(err.contains("no backend specified"), "Got: {}", err);
-}
-
-#[test]
-fn test_default_row_limit() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    assert_eq!(config.default_row_limit, Some(500));
-}
-
-#[test]
-fn test_no_limit_flag() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-        a.no_limit = true;
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    assert_eq!(config.default_row_limit, None);
-}
-
-#[test]
-fn test_default_timeout() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    assert_eq!(config.query_timeout_secs, 60);
-}
-
-#[test]
-fn test_default_allow_write_is_false() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    assert!(!config.allow_write);
-}
-
-#[test]
-fn test_config_file_not_found_errors() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-    });
-
-    let bad_path = PathBuf::from("/nonexistent/config.toml");
-    let result = load_from_exec_args(&args, false, false, Some(&bad_path));
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(err.contains("config file not found"), "Got: {}", err);
-}
-
-#[test]
-fn test_explicit_limit_overrides_default() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-        a.limit = Some(100);
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    assert_eq!(config.default_row_limit, Some(100));
-}
-
-#[test]
-fn test_explicit_timeout_overrides_default() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-        a.timeout = Some(120);
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    assert_eq!(config.query_timeout_secs, 120);
-}
-
-#[test]
-fn test_no_limit_overrides_explicit_limit() {
-    let args = make_exec_args(|a| {
-        a.backend = Some("sqlserver".to_string());
-        a.server = Some("localhost".to_string());
-        a.windows_auth = true;
-        a.limit = Some(100);
-        a.no_limit = true;
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    assert_eq!(config.default_row_limit, None);
-}
-
-// --- T002: Unit tests for non_empty ---
+// =====================================================================
+// T002: Unit tests for non_empty
+// =====================================================================
 
 #[test]
 fn test_non_empty_none() {
@@ -237,12 +70,13 @@ fn test_non_empty_value() {
     assert_eq!(non_empty(Some("value")), Some("value"));
 }
 
-// --- T003: Unit tests for env_non_empty ---
+// =====================================================================
+// T003: Unit tests for env_non_empty
+// =====================================================================
 
 #[test]
 fn test_env_non_empty_unset() {
     let _guard = EnvGuard::new(&[]);
-    // Ensure the var is not set
     unsafe { std::env::remove_var("TEST_ENV_NON_EMPTY_UNSET"); }
     assert_eq!(env_non_empty("TEST_ENV_NON_EMPTY_UNSET"), None);
 }
@@ -259,7 +93,165 @@ fn test_env_non_empty_value() {
     assert_eq!(env_non_empty("TEST_ENV_NON_EMPTY_VAL"), Some("value".to_string()));
 }
 
-// --- T006: Standard Databricks env var fallback (US1) ---
+// =====================================================================
+// T004: Unit tests for default_config_path()
+// =====================================================================
+
+#[test]
+fn test_default_config_path_with_home() {
+    let _guard = EnvGuard::new(&[("HOME", "/Users/testuser")]);
+    let path = default_config_path();
+    assert_eq!(
+        path,
+        Some(PathBuf::from("/Users/testuser/.config/dbtoon/config.toml"))
+    );
+}
+
+#[test]
+fn test_default_config_path_no_home() {
+    let _guard = EnvGuard::new(&[]);
+    unsafe { std::env::remove_var("HOME"); }
+    let path = default_config_path();
+    assert_eq!(path, None);
+}
+
+// =====================================================================
+// T005: Unit tests for resolve_env_var()
+// =====================================================================
+
+#[test]
+fn test_resolve_env_var_literal_passthrough() {
+    let result = resolve_env_var("plain_value").unwrap();
+    assert_eq!(result, "plain_value");
+}
+
+#[test]
+fn test_resolve_env_var_dollar_reference() {
+    let _guard = EnvGuard::new(&[("TEST_RESOLVE_VAR", "resolved_value")]);
+    let result = resolve_env_var("$TEST_RESOLVE_VAR").unwrap();
+    assert_eq!(result, "resolved_value");
+}
+
+#[test]
+fn test_resolve_env_var_dollar_dollar_escape() {
+    let result = resolve_env_var("$$pecial").unwrap();
+    assert_eq!(result, "$pecial");
+}
+
+#[test]
+fn test_resolve_env_var_unset_var_error() {
+    let _guard = EnvGuard::new(&[]);
+    unsafe { std::env::remove_var("NONEXISTENT_TEST_VAR_009"); }
+    let result = resolve_env_var("$NONEXISTENT_TEST_VAR_009");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("NONEXISTENT_TEST_VAR_009"), "Got: {}", err);
+    assert!(err.contains("not set"), "Got: {}", err);
+}
+
+#[test]
+fn test_resolve_profile_string_none() {
+    let result = resolve_profile_string(None).unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_resolve_profile_string_literal() {
+    let result = resolve_profile_string(Some("literal")).unwrap();
+    assert_eq!(result, Some("literal".to_string()));
+}
+
+#[test]
+fn test_resolve_profile_string_var() {
+    let _guard = EnvGuard::new(&[("TEST_PROFILE_STR", "resolved")]);
+    let result = resolve_profile_string(Some("$TEST_PROFILE_STR")).unwrap();
+    assert_eq!(result, Some("resolved".to_string()));
+}
+
+#[test]
+fn test_resolve_profile_secret_var() {
+    let _guard = EnvGuard::new(&[("TEST_PROFILE_SECRET", "secret_val")]);
+    let result = resolve_profile_secret(Some("$TEST_PROFILE_SECRET")).unwrap();
+    assert_eq!(result.unwrap().expose_secret(), "secret_val");
+}
+
+// =====================================================================
+// T006: CLI parsing tests — covered in cli_test.rs
+// =====================================================================
+
+// =====================================================================
+// T007: Config-missing error directs user to `dbtoon init`
+// =====================================================================
+
+#[test]
+fn test_config_missing_error_mentions_init() {
+    let _guard = EnvGuard::new(&[("HOME", "/tmp/dbtoon-test-nonexistent")]);
+    let result = load_toml_config_required(None);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("dbtoon init"), "Error should mention 'dbtoon init', got: {}", err);
+}
+
+#[test]
+fn test_config_explicit_not_found_errors() {
+    let bad_path = PathBuf::from("/nonexistent/config.toml");
+    let result = load_toml_config_required(Some(&bad_path));
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("config file not found"), "Got: {}", err);
+    assert!(err.contains("dbtoon init"), "Got: {}", err);
+}
+
+// =====================================================================
+// Profile loading and backend config tests
+// =====================================================================
+
+#[test]
+fn test_sqlserver_windows_auth_config() {
+    let profile = TomlProfile {
+        backend: Some("sqlserver".to_string()),
+        server: Some("localhost".to_string()),
+        database: Some("testdb".to_string()),
+        windows_auth: Some(true),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, None, None).unwrap();
+    match &backend {
+        BackendConfig::SqlServer { server, database, auth, .. } => {
+            assert_eq!(server, "localhost");
+            assert_eq!(database.as_deref(), Some("testdb"));
+            assert!(matches!(auth, SqlServerAuth::WindowsIntegrated));
+        }
+        _ => panic!("Expected SqlServer backend"),
+    }
+}
+
+#[test]
+fn test_sqlserver_sql_auth_config() {
+    let profile = TomlProfile {
+        backend: Some("sqlserver".to_string()),
+        server: Some("localhost".to_string()),
+        username: Some("sa".to_string()),
+        password: Some("secret".to_string()),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, None, None).unwrap();
+    match &backend {
+        BackendConfig::SqlServer { auth, .. } => {
+            assert!(matches!(auth, SqlServerAuth::SqlLogin { .. }));
+        }
+        _ => panic!("Expected SqlServer backend"),
+    }
+}
+
+#[test]
+fn test_missing_backend_errors() {
+    let profile = TomlProfile::default();
+    let result = config::build_backend_config(&profile, None, None);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("backend"), "Got: {}", err);
+}
 
 #[test]
 fn test_databricks_std_env_fallback() {
@@ -271,12 +263,12 @@ fn test_databricks_std_env_fallback() {
         ("DATABRICKS_SCHEMA", "std-schema"),
     ]);
 
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
+    let profile = TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, None, None).unwrap();
+    match &backend {
         BackendConfig::Databricks { host, token, warehouse_id, catalog, schema } => {
             assert_eq!(host, "https://std-host.azuredatabricks.net");
             assert_eq!(token.expose_secret(), "dapi-std-token");
@@ -288,90 +280,25 @@ fn test_databricks_std_env_fallback() {
     }
 }
 
-// --- T007: dbtoon-specific env overrides standard env (US1) ---
-
-#[test]
-fn test_dbtoon_env_overrides_std_env() {
-    let _guard = EnvGuard::new(&[
-        ("DATABRICKS_HOST", "https://std-host.azuredatabricks.net"),
-        ("DATABRICKS_TOKEN", "dapi-std-token"),
-        ("DATABRICKS_SQL_WAREHOUSE_ID", "std-warehouse"),
-        ("DATABRICKS_CATALOG", "std-catalog"),
-        ("DATABRICKS_SCHEMA", "std-schema"),
-    ]);
-
-    // Simulate clap having resolved dbtoon-specific env vars into args
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-        a.host = Some("https://dbtoon-host.azuredatabricks.net".to_string());
-        a.token = Some("dapi-dbtoon-token".to_string());
-        a.warehouse = Some("dbtoon-warehouse".to_string());
-        a.catalog = Some("dbtoon-catalog".to_string());
-        a.schema = Some("dbtoon-schema".to_string());
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::Databricks { host, token, warehouse_id, catalog, schema } => {
-            assert_eq!(host, "https://dbtoon-host.azuredatabricks.net");
-            assert_eq!(token.expose_secret(), "dapi-dbtoon-token");
-            assert_eq!(warehouse_id, "dbtoon-warehouse");
-            assert_eq!(catalog.as_deref(), Some("dbtoon-catalog"));
-            assert_eq!(schema.as_deref(), Some("dbtoon-schema"));
-        }
-        _ => panic!("Expected Databricks backend"),
-    }
-}
-
-fn make_list_warehouses_args(overrides: impl FnOnce(&mut ListWarehousesArgs)) -> ListWarehousesArgs {
-    let mut args = ListWarehousesArgs {
-        host: None,
-        token: None,
-        profile: None,
-    };
-    overrides(&mut args);
-    args
-}
-
-/// Write a TOML config to a temp file and return its path.
-fn write_temp_toml(content: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join("dbtoon-test");
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join(format!("config-{}.toml", std::process::id()));
-    std::fs::write(&path, content).unwrap();
-    path
-}
-
-// --- T010: TOML profile overrides standard env vars (US2) ---
-
 #[test]
 fn test_toml_profile_overrides_std_env() {
     let _guard = EnvGuard::new(&[
         ("DATABRICKS_HOST", "https://std-host.azuredatabricks.net"),
         ("DATABRICKS_TOKEN", "dapi-std-token"),
         ("DATABRICKS_SQL_WAREHOUSE_ID", "std-warehouse"),
-        ("DATABRICKS_CATALOG", "std-catalog"),
-        ("DATABRICKS_SCHEMA", "std-schema"),
     ]);
 
-    let toml_content = r#"
-[profiles.test]
-backend = "databricks"
-host = "https://toml-host.azuredatabricks.net"
-token = "dapi-toml-token"
-warehouse_id = "toml-warehouse"
-catalog = "toml-catalog"
-schema = "toml-schema"
-"#;
-    let config_path = write_temp_toml(toml_content);
-
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-        a.profile = Some("test".to_string());
-    });
-
-    let config = load_from_exec_args(&args, false, false, Some(&config_path)).unwrap();
-    match &config.backend {
+    let profile = TomlProfile {
+        backend: Some("databricks".to_string()),
+        host: Some("https://toml-host.azuredatabricks.net".to_string()),
+        token: Some("dapi-toml-token".to_string()),
+        warehouse_id: Some("toml-warehouse".to_string()),
+        catalog: Some("toml-catalog".to_string()),
+        schema: Some("toml-schema".to_string()),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, None, None).unwrap();
+    match &backend {
         BackendConfig::Databricks { host, token, warehouse_id, catalog, schema } => {
             assert_eq!(host, "https://toml-host.azuredatabricks.net");
             assert_eq!(token.expose_secret(), "dapi-toml-token");
@@ -381,11 +308,7 @@ schema = "toml-schema"
         }
         _ => panic!("Expected Databricks backend"),
     }
-
-    std::fs::remove_file(&config_path).ok();
 }
-
-// --- T011: Partial TOML profile falls through to standard env (US2) ---
 
 #[test]
 fn test_toml_partial_profile_falls_through_to_std_env() {
@@ -397,246 +320,511 @@ fn test_toml_partial_profile_falls_through_to_std_env() {
         ("DATABRICKS_SCHEMA", "std-schema"),
     ]);
 
-    let toml_content = r#"
-[profiles.partial]
-backend = "databricks"
-host = "https://toml-host.azuredatabricks.net"
-token = "dapi-toml-token"
-warehouse_id = "toml-warehouse"
-"#;
-    let config_path = write_temp_toml(toml_content);
-
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-        a.profile = Some("partial".to_string());
-    });
-
-    let config = load_from_exec_args(&args, false, false, Some(&config_path)).unwrap();
-    match &config.backend {
+    let profile = TomlProfile {
+        backend: Some("databricks".to_string()),
+        host: Some("https://toml-host.azuredatabricks.net".to_string()),
+        token: Some("dapi-toml-token".to_string()),
+        warehouse_id: Some("toml-warehouse".to_string()),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, None, None).unwrap();
+    match &backend {
         BackendConfig::Databricks { host, catalog, .. } => {
             assert_eq!(host, "https://toml-host.azuredatabricks.net");
             assert_eq!(catalog.as_deref(), Some("env-catalog"));
         }
         _ => panic!("Expected Databricks backend"),
     }
-
-    std::fs::remove_file(&config_path).ok();
 }
 
-// --- T012: list-warehouses standard env var fallback (US2) ---
-
 #[test]
-fn test_list_warehouses_std_env_fallback() {
+fn test_cli_database_override() {
     let _guard = EnvGuard::new(&[
-        ("DATABRICKS_HOST", "https://std-host.azuredatabricks.net"),
-        ("DATABRICKS_TOKEN", "dapi-std-token"),
-        ("DATABRICKS_SQL_WAREHOUSE_ID", "std-warehouse"),
-        ("DATABRICKS_CATALOG", "std-catalog"),
-        ("DATABRICKS_SCHEMA", "std-schema"),
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+        ("DATABRICKS_CATALOG", "env-catalog"),
     ]);
 
-    let args = make_list_warehouses_args(|_| {});
-
-    let config = load_from_list_warehouses_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::Databricks { host, token, warehouse_id, catalog, schema } => {
-            assert_eq!(host, "https://std-host.azuredatabricks.net");
-            assert_eq!(token.expose_secret(), "dapi-std-token");
-            assert_eq!(warehouse_id, "std-warehouse");
-            assert_eq!(catalog.as_deref(), Some("std-catalog"));
-            assert_eq!(schema.as_deref(), Some("std-schema"));
+    let profile = TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, Some("cli-catalog"), None).unwrap();
+    match &backend {
+        BackendConfig::Databricks { catalog, .. } => {
+            assert_eq!(catalog.as_deref(), Some("cli-catalog"));
         }
         _ => panic!("Expected Databricks backend"),
     }
 }
 
-// --- T015: CLI flag overrides all tiers (US3) ---
-
 #[test]
-fn test_cli_flag_overrides_all_tiers() {
+fn test_cli_schema_override() {
     let _guard = EnvGuard::new(&[
-        ("DATABRICKS_HOST", "https://std-host.azuredatabricks.net"),
-        ("DATABRICKS_TOKEN", "dapi-std-token"),
-        ("DATABRICKS_SQL_WAREHOUSE_ID", "std-warehouse"),
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
     ]);
 
-    let toml_content = r#"
-[profiles.test]
-backend = "databricks"
-host = "https://toml-host.azuredatabricks.net"
-token = "dapi-toml-token"
-warehouse_id = "toml-warehouse"
-"#;
-    let config_path = write_temp_toml(toml_content);
-
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-        a.profile = Some("test".to_string());
-        a.host = Some("https://cli-host.azuredatabricks.net".to_string());
-        a.token = Some("dapi-cli-token".to_string());
-        a.warehouse = Some("cli-warehouse".to_string());
-    });
-
-    let config = load_from_exec_args(&args, false, false, Some(&config_path)).unwrap();
-    match &config.backend {
-        BackendConfig::Databricks { host, token, warehouse_id, .. } => {
-            assert_eq!(host, "https://cli-host.azuredatabricks.net");
-            assert_eq!(token.expose_secret(), "dapi-cli-token");
-            assert_eq!(warehouse_id, "cli-warehouse");
-        }
-        _ => panic!("Expected Databricks backend"),
-    }
-
-    std::fs::remove_file(&config_path).ok();
-}
-
-// --- T016: Empty dbtoon env falls through to standard env (US3) ---
-
-#[test]
-fn test_empty_dbtoon_env_falls_through_to_std_env() {
-    let _guard = EnvGuard::new(&[
-        ("DATABRICKS_HOST", "https://std-host.azuredatabricks.net"),
-        ("DATABRICKS_TOKEN", "dapi-std-token"),
-        ("DATABRICKS_SQL_WAREHOUSE_ID", "std-warehouse"),
-    ]);
-
-    // Simulate clap resolving empty DBTOON_DATABRICKS_HOST to Some("")
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-        a.host = Some(String::new());
-        a.token = Some(String::new());
-        a.warehouse = Some(String::new());
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::Databricks { host, token, warehouse_id, .. } => {
-            assert_eq!(host, "https://std-host.azuredatabricks.net");
-            assert_eq!(token.expose_secret(), "dapi-std-token");
-            assert_eq!(warehouse_id, "std-warehouse");
+    let profile = TomlProfile {
+        backend: Some("databricks".to_string()),
+        schema: Some("profile-schema".to_string()),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, None, Some("cli-schema")).unwrap();
+    match &backend {
+        BackendConfig::Databricks { schema, .. } => {
+            assert_eq!(schema.as_deref(), Some("cli-schema"));
         }
         _ => panic!("Expected Databricks backend"),
     }
 }
 
-// --- T017: Empty standard env treated as unset (US3) ---
-
 #[test]
-fn test_empty_std_env_treated_as_unset() {
+fn test_dollar_var_resolution_in_profile() {
     let _guard = EnvGuard::new(&[
-        ("DATABRICKS_HOST", ""),
+        ("MY_HOST", "https://resolved-host.azuredatabricks.net"),
+        ("MY_TOKEN", "dapi-resolved-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
     ]);
 
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-    });
+    let profile = TomlProfile {
+        backend: Some("databricks".to_string()),
+        host: Some("$MY_HOST".to_string()),
+        token: Some("$MY_TOKEN".to_string()),
+        ..Default::default()
+    };
+    let backend = config::build_backend_config(&profile, None, None).unwrap();
+    match &backend {
+        BackendConfig::Databricks { host, token, .. } => {
+            assert_eq!(host, "https://resolved-host.azuredatabricks.net");
+            assert_eq!(token.expose_secret(), "dapi-resolved-token");
+        }
+        _ => panic!("Expected Databricks backend"),
+    }
+}
 
-    let result = load_from_exec_args(&args, false, false, None);
+#[test]
+fn test_dollar_var_unset_error_in_profile() {
+    let _guard = EnvGuard::new(&[]);
+    unsafe { std::env::remove_var("UNSET_VAR_FOR_TEST_009"); }
+
+    let profile = TomlProfile {
+        backend: Some("databricks".to_string()),
+        host: Some("$UNSET_VAR_FOR_TEST_009".to_string()),
+        ..Default::default()
+    };
+    let result = config::build_backend_config(&profile, None, None);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
-    assert!(err.contains("no host specified"), "Got: {}", err);
+    assert!(err.contains("UNSET_VAR_FOR_TEST_009"), "Got: {}", err);
 }
 
+// =====================================================================
+// Query args config loading
+// =====================================================================
+
 #[test]
-fn test_empty_std_env_catalog_treated_as_none() {
+fn test_load_from_query_args_basic() {
     let _guard = EnvGuard::new(&[
         ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
         ("DATABRICKS_TOKEN", "dapi-token"),
         ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
-        ("DATABRICKS_CATALOG", ""),
     ]);
 
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
+    let toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
     });
 
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert_eq!(app_config.default_row_limit, Some(500));
+    assert_eq!(app_config.query_timeout_secs, 60);
+    assert!(!app_config.allow_write);
+}
+
+#[test]
+fn test_load_from_query_args_no_limit() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+    ]);
+
+    let toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    });
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: true,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert_eq!(app_config.default_row_limit, None);
+}
+
+#[test]
+fn test_load_from_query_args_explicit_limit() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+    ]);
+
+    let toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    });
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: Some(100),
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert_eq!(app_config.default_row_limit, Some(100));
+}
+
+#[test]
+fn test_load_from_query_args_allow_write() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+    ]);
+
+    let toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    });
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: true,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert!(app_config.allow_write);
+}
+
+// =====================================================================
+// T017: Profile loading and config resolution (CLI > profile > defaults > Databricks env)
+// =====================================================================
+
+#[test]
+fn test_toml_defaults_apply_when_profile_missing_field() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+    ]);
+
+    let mut toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    });
+    toml_config.defaults.row_limit = Some(200);
+    toml_config.defaults.timeout = Some(90);
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert_eq!(app_config.default_row_limit, Some(200), "should use defaults.row_limit");
+    assert_eq!(app_config.query_timeout_secs, 90, "should use defaults.timeout");
+}
+
+#[test]
+fn test_cli_limit_overrides_defaults() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+    ]);
+
+    let mut toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    });
+    toml_config.defaults.row_limit = Some(200);
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: Some(50),
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert_eq!(app_config.default_row_limit, Some(50), "CLI limit should override defaults");
+}
+
+// =====================================================================
+// T019: --allow-write flag gating write queries
+// =====================================================================
+
+#[test]
+fn test_allow_write_false_by_default() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+    ]);
+
+    let toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    });
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("INSERT INTO t VALUES(1)".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert!(!app_config.allow_write, "allow_write should be false by default");
+}
+
+#[test]
+fn test_allow_write_from_defaults() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+    ]);
+
+    let mut toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
+    });
+    toml_config.defaults.allow_write = Some(true);
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    assert!(app_config.allow_write, "defaults.allow_write should propagate");
+}
+
+// =====================================================================
+// T038-T039: Full resolution hierarchy integration tests
+// =====================================================================
+
+#[test]
+fn test_full_resolution_hierarchy_cli_wins() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://env-host.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-env-token"),
+        ("DATABRICKS_SQL_WAREHOUSE_ID", "env-wh"),
+        ("DATABRICKS_CATALOG", "env-catalog"),
+    ]);
+
+    // Profile sets catalog, but CLI override should win
+    let mut toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        catalog: Some("profile-catalog".to_string()),
+        ..Default::default()
+    });
+    toml_config.defaults.row_limit = Some(200);
+
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: Some("cli-catalog".to_string()),
+        catalog: None,
+        schema: None,
+        limit: Some(10),
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    match &app_config.backend {
         BackendConfig::Databricks { catalog, .. } => {
-            assert_eq!(catalog.as_deref(), None);
+            assert_eq!(catalog.as_deref(), Some("cli-catalog"), "CLI should win over profile");
         }
         _ => panic!("Expected Databricks backend"),
     }
+    assert_eq!(app_config.default_row_limit, Some(10), "CLI limit should win over defaults");
 }
 
-// --- T018: Independent field resolution (US3) ---
-
 #[test]
-fn test_independent_field_resolution() {
-    let _guard = EnvGuard::new(&[
-        ("DATABRICKS_TOKEN", "std-token"),
-        ("DATABRICKS_SQL_WAREHOUSE_ID", "std-warehouse"),
-    ]);
-
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
-        a.host = Some("https://cli-host.azuredatabricks.net".to_string());
-    });
-
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::Databricks { host, token, warehouse_id, .. } => {
-            assert_eq!(host, "https://cli-host.azuredatabricks.net");
-            assert_eq!(token.expose_secret(), "std-token");
-            assert_eq!(warehouse_id, "std-warehouse");
-        }
-        _ => panic!("Expected Databricks backend"),
-    }
-}
-
-// --- T019: Standard env token fallback (US3) ---
-
-#[test]
-fn test_std_env_token_fallback() {
+fn test_databricks_env_fallback_lowest_priority() {
     let _guard = EnvGuard::new(&[
         ("DATABRICKS_HOST", "https://host.azuredatabricks.net"),
-        ("DATABRICKS_TOKEN", "std-token"),
+        ("DATABRICKS_TOKEN", "dapi-token"),
         ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+        ("DATABRICKS_CATALOG", "env-catalog-fallback"),
     ]);
 
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
+    // Profile does NOT set catalog — env var should be used as fallback
+    let toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        ..Default::default()
     });
 
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::Databricks { token, .. } => {
-            assert_eq!(token.expose_secret(), "std-token");
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
+
+    let app_config = config::load_from_query_args(&args, &toml_config, false, false).unwrap();
+    match &app_config.backend {
+        BackendConfig::Databricks { catalog, .. } => {
+            assert_eq!(catalog.as_deref(), Some("env-catalog-fallback"), "Databricks env var should be used as fallback");
         }
         _ => panic!("Expected Databricks backend"),
     }
 }
 
-// --- T020: Dotenv standard vars participate (US3) ---
-
 #[test]
-fn test_dotenv_std_vars_participate() {
+fn test_dollar_var_unset_is_error_not_fallthrough() {
     let _guard = EnvGuard::new(&[
         ("DATABRICKS_TOKEN", "dapi-token"),
         ("DATABRICKS_SQL_WAREHOUSE_ID", "wh-id"),
+        ("DATABRICKS_HOST", "fallback-host"),
     ]);
+    unsafe { std::env::remove_var("UNSET_HOST_FOR_RESOLUTION_TEST"); }
 
-    let dir = std::env::temp_dir().join("dbtoon-dotenv-test");
-    std::fs::create_dir_all(&dir).unwrap();
-    let env_path = dir.join(".env");
-    std::fs::write(&env_path, "DATABRICKS_HOST=https://dotenv-host.azuredatabricks.net\n").unwrap();
-
-    dotenvy::from_path(&env_path).ok();
-
-    let args = make_exec_args(|a| {
-        a.backend = Some("databricks".to_string());
+    // Profile sets host as $VAR reference to unset var — should error, NOT fall through to DATABRICKS_HOST
+    let toml_config = make_toml_config("dev", TomlProfile {
+        backend: Some("databricks".to_string()),
+        host: Some("$UNSET_HOST_FOR_RESOLUTION_TEST".to_string()),
+        ..Default::default()
     });
 
-    let config = load_from_exec_args(&args, false, false, None).unwrap();
-    match &config.backend {
-        BackendConfig::Databricks { host, .. } => {
-            assert_eq!(host, "https://dotenv-host.azuredatabricks.net");
-        }
-        _ => panic!("Expected Databricks backend"),
-    }
+    let args = dbtoon::cli::QueryArgs {
+        sql: Some("SELECT 1".to_string()),
+        file: None,
+        profile: "dev".to_string(),
+        database: None,
+        catalog: None,
+        schema: None,
+        limit: None,
+        no_limit: false,
+        timeout: None,
+        output: None,
+        allow_write: false,
+    };
 
-    // Cleanup
-    unsafe { std::env::remove_var("DATABRICKS_HOST"); }
-    std::fs::remove_file(&env_path).ok();
-    std::fs::remove_dir(&dir).ok();
+    let result = config::load_from_query_args(&args, &toml_config, false, false);
+    assert!(result.is_err(), "$VAR to unset var should error, not fallthrough");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("UNSET_HOST_FOR_RESOLUTION_TEST"), "Got: {}", err);
+}
+
+// =====================================================================
+// T036: Config-missing error for all config-dependent commands
+// =====================================================================
+
+#[test]
+fn test_config_missing_error_with_explicit_nonexistent_path() {
+    let bad_path = PathBuf::from("/tmp/dbtoon-test-nonexistent-cfg/config.toml");
+    let result = load_toml_config_required(Some(&bad_path));
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("dbtoon init"), "should mention dbtoon init, got: {}", err);
+}
+
+#[test]
+fn test_profile_not_found_errors() {
+    let toml_config = TomlConfig::default();
+    let result = config::load_profile(&toml_config, "nonexistent");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not found"), "Got: {}", err);
 }

--- a/tests/unit/init_test.rs
+++ b/tests/unit/init_test.rs
@@ -1,0 +1,141 @@
+use dbtoon::init;
+use std::sync::Mutex;
+
+// --- Env var test infrastructure (shared pattern) ---
+
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+struct EnvGuard {
+    keys: Vec<String>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn new(vars: &[(&str, &str)]) -> Self {
+        let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        for (key, val) in vars {
+            unsafe { std::env::set_var(key, val); }
+        }
+        EnvGuard {
+            keys: vars.iter().map(|(k, _)| k.to_string()).collect(),
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for key in &self.keys {
+            unsafe { std::env::remove_var(key); }
+        }
+    }
+}
+
+// =====================================================================
+// T013: Init template generation tests
+// =====================================================================
+
+#[test]
+fn test_init_creates_config_file() {
+    let dir = std::env::temp_dir().join("dbtoon-init-test-creates");
+    let _ = std::fs::remove_dir_all(&dir);
+    let config_path = dir.join("config.toml");
+
+    let result = init::run_init(&config_path);
+    assert!(result.is_ok(), "init should succeed: {:?}", result.err());
+    assert!(config_path.exists(), "config file should be created");
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(content.contains("[defaults]"), "should contain [defaults] section");
+    assert!(content.contains("row_limit"), "should contain row_limit");
+    assert!(content.contains("timeout"), "should contain timeout");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn test_init_creates_directory_tree() {
+    let dir = std::env::temp_dir().join("dbtoon-init-test-mkdir/deep/nested");
+    let _ = std::fs::remove_dir_all(std::env::temp_dir().join("dbtoon-init-test-mkdir"));
+    let config_path = dir.join("config.toml");
+
+    let result = init::run_init(&config_path);
+    assert!(result.is_ok(), "init should create directories: {:?}", result.err());
+    assert!(config_path.exists());
+
+    std::fs::remove_dir_all(std::env::temp_dir().join("dbtoon-init-test-mkdir")).ok();
+}
+
+#[test]
+fn test_init_default_template_has_commented_profiles() {
+    let _guard = EnvGuard::new(&[]);
+    // Ensure no Databricks env vars are set
+    unsafe {
+        std::env::remove_var("DATABRICKS_HOST");
+        std::env::remove_var("DATABRICKS_TOKEN");
+    }
+
+    let dir = std::env::temp_dir().join("dbtoon-init-test-commented");
+    let _ = std::fs::remove_dir_all(&dir);
+    let config_path = dir.join("config.toml");
+
+    init::run_init(&config_path).unwrap();
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    // When no Databricks env vars are set, profiles should be commented out
+    assert!(content.contains("# [profiles."), "profiles should be commented out");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn test_init_databricks_env_detected_uncomments_profile() {
+    let _guard = EnvGuard::new(&[
+        ("DATABRICKS_HOST", "https://ws.azuredatabricks.net"),
+        ("DATABRICKS_TOKEN", "dapi-test-token"),
+    ]);
+
+    let dir = std::env::temp_dir().join("dbtoon-init-test-dbx");
+    let _ = std::fs::remove_dir_all(&dir);
+    let config_path = dir.join("config.toml");
+
+    init::run_init(&config_path).unwrap();
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    // When Databricks env vars are detected, the Databricks profile should be uncommented
+    assert!(
+        content.contains("[profiles.databricks]") || content.contains("[profiles.databricks_example]"),
+        "Databricks profile should be uncommented, got:\n{}",
+        content
+    );
+    assert!(content.contains("$DATABRICKS_HOST"), "should reference $DATABRICKS_HOST");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// =====================================================================
+// T014: Init when config already exists
+// =====================================================================
+
+#[test]
+fn test_init_already_exists_does_not_overwrite() {
+    let dir = std::env::temp_dir().join("dbtoon-init-test-exists");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let config_path = dir.join("config.toml");
+
+    // Write an existing config
+    let original_content = "# existing config\n[defaults]\nrow_limit = 999\n";
+    std::fs::write(&config_path, original_content).unwrap();
+
+    let result = init::run_init(&config_path);
+    assert!(result.is_err(), "init should error when config exists");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("already exists"), "Error should mention 'already exists', got: {}", err);
+
+    // Verify file was NOT overwritten
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    assert_eq!(content, original_content, "file should not be overwritten");
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,5 +1,8 @@
+mod cli_test;
 mod config_test;
 mod format_arrow_test;
+mod init_test;
+mod profile_test;
 mod format_columnar_test;
 mod format_csv_test;
 mod format_detect_test;

--- a/tests/unit/profile_test.rs
+++ b/tests/unit/profile_test.rs
@@ -1,0 +1,328 @@
+use dbtoon::profile;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+// --- Env var test infrastructure ---
+
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+struct EnvGuard {
+    keys: Vec<String>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn new(vars: &[(&str, &str)]) -> Self {
+        let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        for (key, val) in vars {
+            unsafe { std::env::set_var(key, val); }
+        }
+        EnvGuard {
+            keys: vars.iter().map(|(k, _)| k.to_string()).collect(),
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for key in &self.keys {
+            unsafe { std::env::remove_var(key); }
+        }
+    }
+}
+
+fn write_temp_config(content: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join("dbtoon-profile-test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("config-{}-{:?}.toml", std::process::id(), std::thread::current().id()));
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+// =====================================================================
+// T024: profile create tests
+// =====================================================================
+
+#[test]
+fn test_profile_create_sqlserver_defaults() {
+    let path = write_temp_config("[defaults]\nrow_limit = 500\n");
+    let result = profile::create_profile(&path, "mydb", "sqlserver", &[]);
+    assert!(result.is_ok(), "create should succeed: {:?}", result.err());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(content.contains("[profiles.mydb]"), "should contain profile section");
+    assert!(content.contains("backend = \"sqlserver\""), "should set backend");
+    // Should have $VAR defaults for sqlserver fields
+    assert!(content.contains("server"), "should have server field");
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_create_databricks_defaults() {
+    let path = write_temp_config("[defaults]\nrow_limit = 500\n");
+    let result = profile::create_profile(&path, "dbx", "databricks", &[]);
+    assert!(result.is_ok());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(content.contains("[profiles.dbx]"));
+    assert!(content.contains("backend = \"databricks\""));
+    assert!(content.contains("$DATABRICKS_HOST"));
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_create_with_set_overrides() {
+    let path = write_temp_config("[defaults]\n");
+    let result = profile::create_profile(
+        &path, "mydb", "sqlserver",
+        &["server=localhost".to_string(), "database=testdb".to_string()],
+    );
+    assert!(result.is_ok());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(content.contains("server = \"localhost\""), "should have overridden server");
+    assert!(content.contains("database = \"testdb\""), "should have overridden database");
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_create_duplicate_rejected() {
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"sqlserver\"\nserver = \"localhost\"\n");
+    let result = profile::create_profile(&path, "mydb", "sqlserver", &[]);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("already exists"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_create_invalid_backend() {
+    let path = write_temp_config("[defaults]\n");
+    let result = profile::create_profile(&path, "mydb", "postgres", &[]);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("unknown backend") || err.contains("backend"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_create_invalid_field() {
+    let path = write_temp_config("[defaults]\n");
+    let result = profile::create_profile(
+        &path, "mydb", "sqlserver",
+        &["not_a_field=value".to_string()],
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not_a_field"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}
+
+// =====================================================================
+// T025: profile edit tests
+// =====================================================================
+
+#[test]
+fn test_profile_edit_set_field() {
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"sqlserver\"\nserver = \"old\"\n");
+    let result = profile::edit_profile(&path, "mydb", &["server=new".to_string()], &[]);
+    assert!(result.is_ok(), "{:?}", result.err());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(content.contains("server = \"new\""), "Got:\n{}", content);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_edit_set_empty_removes() {
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"sqlserver\"\nserver = \"localhost\"\ndatabase = \"old\"\n");
+    let result = profile::edit_profile(&path, "mydb", &["database=".to_string()], &[]);
+    assert!(result.is_ok(), "{:?}", result.err());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(!content.contains("database"), "database should be removed, got:\n{}", content);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_edit_unset_removes() {
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"sqlserver\"\nserver = \"localhost\"\ndatabase = \"old\"\n");
+    let result = profile::edit_profile(&path, "mydb", &[], &["database".to_string()]);
+    assert!(result.is_ok(), "{:?}", result.err());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(!content.contains("database"), "database should be removed, got:\n{}", content);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_edit_invalid_field() {
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"sqlserver\"\nserver = \"localhost\"\n");
+    let result = profile::edit_profile(&path, "mydb", &["invalid_field=value".to_string()], &[]);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("invalid_field"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_edit_nonexistent_profile() {
+    let path = write_temp_config("[defaults]\n");
+    let result = profile::edit_profile(&path, "nonexistent", &["server=localhost".to_string()], &[]);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not found"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}
+
+// =====================================================================
+// T047: profile test — missing required fields error
+// =====================================================================
+
+#[test]
+fn test_profile_test_missing_required_fields() {
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"sqlserver\"\n");
+    let result = profile::test_profile(&path, "mydb");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("server") || err.contains("required"), "should report missing required fields, got: {}", err);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_test_nonexistent() {
+    let path = write_temp_config("[defaults]\n");
+    let result = profile::test_profile(&path, "nonexistent");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not found"), "Got: {}", err);
+    std::fs::remove_file(&path).ok();
+}
+
+// =====================================================================
+// T026: profile show, list, delete, rename tests
+// =====================================================================
+
+#[test]
+fn test_profile_show_resolved_values() {
+    let _guard = EnvGuard::new(&[("MY_HOST", "resolved-host")]);
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"databricks\"\nhost = \"$MY_HOST\"\ntoken = \"literal-token\"\nwarehouse_id = \"wh-1\"\n");
+
+    let output = profile::show_profile(&path, "mydb", false).unwrap();
+    assert!(output.contains("host"), "should show host field");
+    assert!(output.contains("MY_HOST"), "should show env var name");
+    // Token should be masked
+    assert!(output.contains("token"), "should show token field");
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_show_with_show_secrets() {
+    let _guard = EnvGuard::new(&[("MY_TOKEN", "secret-value")]);
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"databricks\"\nhost = \"literal-host\"\ntoken = \"$MY_TOKEN\"\nwarehouse_id = \"wh-1\"\n");
+
+    let output = profile::show_profile(&path, "mydb", true).unwrap();
+    assert!(output.contains("secret-value"), "should reveal secret with show_secrets=true");
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_show_unset_env_warning() {
+    let _guard = EnvGuard::new(&[]);
+    unsafe { std::env::remove_var("UNSET_HOST_VAR_009"); }
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"databricks\"\nhost = \"$UNSET_HOST_VAR_009\"\ntoken = \"tok\"\nwarehouse_id = \"wh\"\n");
+
+    let output = profile::show_profile(&path, "mydb", false).unwrap();
+    assert!(
+        output.contains("not set") || output.contains("WARNING") || output.contains("⚠"),
+        "should warn about unset env var, got:\n{}", output
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_list() {
+    let path = write_temp_config("[defaults]\n\n[profiles.first]\nbackend = \"sqlserver\"\nserver = \"a\"\n\n[profiles.second]\nbackend = \"databricks\"\nhost = \"b\"\ntoken = \"c\"\nwarehouse_id = \"d\"\n");
+
+    let names = profile::list_profiles(&path).unwrap();
+    assert!(names.contains(&"first".to_string()));
+    assert!(names.contains(&"second".to_string()));
+    assert_eq!(names.len(), 2);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_delete() {
+    let path = write_temp_config("[defaults]\n\n[profiles.mydb]\nbackend = \"sqlserver\"\nserver = \"localhost\"\n");
+    let result = profile::delete_profile(&path, "mydb");
+    assert!(result.is_ok(), "{:?}", result.err());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(!content.contains("[profiles.mydb]"), "profile should be deleted");
+    assert!(!content.contains("server = \"localhost\""), "profile fields should be deleted");
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_delete_nonexistent() {
+    let path = write_temp_config("[defaults]\n");
+    let result = profile::delete_profile(&path, "nonexistent");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not found"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_rename() {
+    let path = write_temp_config("[defaults]\n\n[profiles.old]\nbackend = \"sqlserver\"\nserver = \"localhost\"\n");
+    let result = profile::rename_profile(&path, "old", "new");
+    assert!(result.is_ok(), "{:?}", result.err());
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(!content.contains("[profiles.old]"), "old name should be gone");
+    assert!(content.contains("[profiles.new]"), "new name should exist");
+    assert!(content.contains("server = \"localhost\""), "fields should be preserved");
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_rename_target_exists() {
+    let path = write_temp_config("[defaults]\n\n[profiles.old]\nbackend = \"sqlserver\"\nserver = \"a\"\n\n[profiles.new]\nbackend = \"sqlserver\"\nserver = \"b\"\n");
+    let result = profile::rename_profile(&path, "old", "new");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("already exists"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn test_profile_rename_source_nonexistent() {
+    let path = write_temp_config("[defaults]\n");
+    let result = profile::rename_profile(&path, "nonexistent", "new");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not found"), "Got: {}", err);
+
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## Summary

- Replace `exec-read`/`exec-write` with unified `dbtoon query -P <profile>` command
- Add `dbtoon init` for config file bootstrapping with Databricks env var detection
- Add `profile` subcommands (create/edit/show/list/test/delete/rename) using `toml_edit` for comment-preserving writes
- Add `warehouse list -P <profile>` for Databricks warehouse listing
- Implement `$VAR` resolution in TOML profiles with 4-tier config resolution (CLI > profile > defaults > Databricks env vars)
- Remove all `DBTOON_*` env vars, legacy commands (`exec-read`, `exec-write`, `list-warehouses`), and `directories` crate

## Test plan

- [x] 244 tests passing (0 failures)
- [x] 0 clippy warnings
- [x] 0 test warnings
- [ ] Manual smoke test: `dbtoon init` → `dbtoon profile create` → `dbtoon query -P <profile>`
- [ ] Verify legacy commands (`exec-read`, `exec-write`) are rejected by clap

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)